### PR TITLE
Fix patches for kernel 6.1.13+

### DIFF
--- a/8002-brcmfmac-Fix-firmware-name-for-bcm4355-firmware.patch
+++ b/8002-brcmfmac-Fix-firmware-name-for-bcm4355-firmware.patch
@@ -12,17 +12,17 @@ diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c b/drivers/n
 index ab3333c10..4ceb269ce 100644
 --- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
 +++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/pcie.c
-@@ -66,6 +66,7 @@ BRCMF_FW_CLM_DEF(4378B1, "brcmfmac4378b1-pcie");
- BRCMF_FW_CLM_DEF(4378B3, "brcmfmac4378b3-pcie");
+@@ -65,6 +65,7 @@ BRCMF_FW_CLM_DEF(4378B1, "brcmfmac4378b1-pcie");
+ BRCMF_FW_CLM_DEF(4378B1, "brcmfmac4378b1-pcie");
  BRCMF_FW_CLM_DEF(4387C2, "brcmfmac4387c2-pcie");
  BRCMF_FW_DEF(4355, "brcmfmac89459-pcie");
 +BRCMF_FW_CLM_DEF(4355C1, "brcmfmac4355c1-pcie");
  
  /* firmware config files */
  MODULE_FIRMWARE(BRCMF_FW_DEFAULT_PATH "brcmfmac*-pcie.txt");
-@@ -101,7 +102,8 @@ static const struct brcmf_firmware_mapping brcmf_pcie_fwnames[] = {
- 	BRCMF_FW_ENTRY(BRCM_CC_4378_CHIP_ID, 0x0000000F, 4378B1), /* revision ID 3 */
- 	BRCMF_FW_ENTRY(BRCM_CC_4378_CHIP_ID, 0xFFFFFFE0, 4378B3), /* revision ID 5 */
+@@ -99,7 +100,8 @@ static const struct brcmf_firmware_mapping brcmf_pcie_fwnames[] = {
+ 	BRCMF_FW_ENTRY(BRCM_CC_4377_CHIP_ID, 0xFFFFFFFF, 4377B3), /* revision ID 4 */
+ 	BRCMF_FW_ENTRY(BRCM_CC_4378_CHIP_ID, 0xFFFFFFFF, 4378B1), /* revision ID 3 */
  	BRCMF_FW_ENTRY(BRCM_CC_4387_CHIP_ID, 0xFFFFFFFF, 4387C2), /* revision ID 7 */
 -	BRCMF_FW_ENTRY(CY_CC_89459_CHIP_ID, 0xFFFFFFFF, 4355),
 +	BRCMF_FW_ENTRY(CY_CC_89459_CHIP_ID, 0x00000FFF, 4355),


### PR DESCRIPTION
This fixes the context in
`8002-brcmfmac-Fix-firmware-name-for-bcm4355-firmware.patch`, which allows it to be applied with `git apply`. This change will make the patch stop working when using `git apply` for older versions.