### PR TITLE
Fix 2009 patch to support v6.5.11 of linux

### DIFF
--- a/2009-apple-gmux-allow-switching-to-igpu-at-probe.patch
+++ b/2009-apple-gmux-allow-switching-to-igpu-at-probe.patch
@@ -10,6 +10,7 @@ This isn't really upstreamable, what we want upstream is the ability to
 switch at runtime (so both gpus need to be able to probe the eDP panel).
 
 Based off of work by Kerem Karabay <kekrby@gmail.com>
+
 ---
  drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c |  3 +++
  drivers/gpu/vga/vga_switcheroo.c        |  7 +------
@@ -18,19 +19,19 @@ Based off of work by Kerem Karabay <kekrby@gmail.com>
  4 files changed, 24 insertions(+), 6 deletions(-)
 
 diff --git a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-index 3fe277bc233f..ee7792a350e5 100644
+index e06009966428..196fcd776e24 100644
 --- a/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
 +++ b/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c
-@@ -2058,6 +2058,9 @@ static int amdgpu_pci_probe(struct pci_dev *pdev,
- 	int ret, retry = 0, i;
- 	bool supports_atomic = false;
+@@ -2094,6 +2094,9 @@ static int amdgpu_pci_probe(struct pci_dev *pdev,
+        int ret, retry = 0, i;
+        bool supports_atomic = false;
  
-+	if (vga_switcheroo_client_probe_defer(pdev))
-+		return -EPROBE_DEFER;
++       if (vga_switcheroo_client_probe_defer(pdev))
++               return -EPROBE_DEFER;
 +
- 	/* skip devices which are owned by radeon */
- 	for (i = 0; i < ARRAY_SIZE(amdgpu_unsupported_pciidlist); i++) {
- 		if (amdgpu_unsupported_pciidlist[i] == pdev->device)
+        /* skip devices which are owned by radeon */
+        for (i = 0; i < ARRAY_SIZE(amdgpu_unsupported_pciidlist); i++) {
+                if (amdgpu_unsupported_pciidlist[i] == pdev->device)
 diff --git a/drivers/gpu/vga/vga_switcheroo.c b/drivers/gpu/vga/vga_switcheroo.c
 index 365e6ddbe90f..cf357cd3389d 100644
 --- a/drivers/gpu/vga/vga_switcheroo.c
@@ -38,31 +39,31 @@ index 365e6ddbe90f..cf357cd3389d 100644
 @@ -438,12 +438,7 @@ find_active_client(struct list_head *head)
  bool vga_switcheroo_client_probe_defer(struct pci_dev *pdev)
  {
- 	if ((pdev->class >> 16) == PCI_BASE_CLASS_DISPLAY) {
--		/*
--		 * apple-gmux is needed on pre-retina MacBook Pro
--		 * to probe the panel if pdev is the inactive GPU.
--		 */
--		if (apple_gmux_present() && pdev != vga_default_device() &&
--		    !vgasr_priv.handler_flags)
-+		if (apple_gmux_present() && !vgasr_priv.handler_flags)
- 			return true;
- 	}
+        if ((pdev->class >> 16) == PCI_BASE_CLASS_DISPLAY) {
+-               /*
+-                * apple-gmux is needed on pre-retina MacBook Pro
+-                * to probe the panel if pdev is the inactive GPU.
+-                */
+-               if (apple_gmux_present() && pdev != vga_default_device() &&
+-                   !vgasr_priv.handler_flags)
++               if (apple_gmux_present() && !vgasr_priv.handler_flags)
+                        return true;
+        }
  
 diff --git a/drivers/pci/vgaarb.c b/drivers/pci/vgaarb.c
-index f80b6ec88dc3..952652944fbd 100644
+index 5a696078b382..ab8275fdc0e1 100644
 --- a/drivers/pci/vgaarb.c
 +++ b/drivers/pci/vgaarb.c
 @@ -145,6 +145,7 @@ void vga_set_default_device(struct pci_dev *pdev)
- 	pci_dev_put(vga_default);
- 	vga_default = pci_dev_get(pdev);
+        pci_dev_put(vga_default);
+        vga_default = pci_dev_get(pdev);
  }
 +EXPORT_SYMBOL_GPL(vga_set_default_device);
  
  /**
   * vga_remove_vgacon - deactivete vga console
 diff --git a/drivers/platform/x86/apple-gmux.c b/drivers/platform/x86/apple-gmux.c
-index e02b4ae..71b5cb38 100644
+index 1417e230edbd..3fef1afd9d24 100644
 --- a/drivers/platform/x86/apple-gmux.c
 +++ b/drivers/platform/x86/apple-gmux.c
 @@ -21,6 +21,7 @@
@@ -73,37 +74,39 @@ index e02b4ae..71b5cb38 100644
  #include <linux/debugfs.h>
  #include <acpi/video.h>
  #include <asm/io.h>
-@@ -105,6 +106,10 @@ struct apple_gmux_config {
+@@ -107,6 +108,11 @@ struct apple_gmux_config {
  
- # define MMIO_GMUX_MAX_BRIGHTNESS	0xffff
+ # define MMIO_GMUX_MAX_BRIGHTNESS      0xffff
  
 +static bool force_igd;
 +module_param(force_igd, bool, 0);
 +MODULE_PARM_DESC(force_idg, "Switch gpu to igd on module load. Make sure that you have apple-set-os set up and the iGPU is in `lspci -s 00:02.0`. (default: false) (bool)");
 +
++
  static u8 gmux_pio_read8(struct apple_gmux_data *gmux_data, int port)
  {
- 	return inb(gmux_data->iostart + port);
-@@ -933,6 +938,19 @@ static int gmux_probe(struct pnp_dev *pnp, const struct pnp_device_id *id)
- 	gmux_enable_interrupts(gmux_data);
- 	gmux_read_switch_state(gmux_data);
+        return inb(gmux_data->iostart + port);
+@@ -945,6 +951,19 @@ static int gmux_probe(struct pnp_dev *pnp, const struct pnp_device_id *id)
+        gmux_enable_interrupts(gmux_data);
+        gmux_read_switch_state(gmux_data);
  
-+	if (force_igd) {
-+		struct pci_dev *pdev;
++       if (force_igd) {
++               struct pci_dev *pdev;
 +
-+		pdev = pci_get_domain_bus_and_slot(0, 0, PCI_DEVFN(2, 0));
-+		if (pdev) {
-+			pr_info("Switching to IGD");
-+			gmux_switchto(VGA_SWITCHEROO_IGD);
-+			vga_set_default_device(pdev);
-+		} else {
-+			pr_err("force_idg is true, but couldn't find iGPU at 00:02.0! Is apple-set-os working?");
-+		}
-+	}
++               pdev = pci_get_domain_bus_and_slot(0, 0, PCI_DEVFN(2, 0));
++               if (pdev) {
++                       pr_info("Switching to IGD");
++                       gmux_switchto(VGA_SWITCHEROO_IGD);
++                       vga_set_default_device(pdev);
++               } else {
++                       pr_err("force_idg is true, but couldn't find iGPU at 00:02.0! Is apple-set-os working?");
++               }
++       }
 +
- 	/*
- 	 * Retina MacBook Pros cannot switch the panel's AUX separately
- 	 * and need eDP pre-calibration. They are distinguishable from
+        /*
+         * Retina MacBook Pros cannot switch the panel's AUX separately
+         * and need eDP pre-calibration. They are distinguishable from
 -- 
-1.8.3.1
+2.41.0
+
 


### PR DESCRIPTION
2009 was failing a build for Fedora:
```
+ '[' '!' -f /root/rpmbuild/SOURCES/2009-apple-gmux-allow-switching-to-igpu-at-probe.patch ']'
Patch20: 2009-apple-gmux-allow-switching-to-igpu-at-probe.patch
+ case "$patch" in
+ git --work-tree=. apply
error: patch failed: drivers/platform/x86/apple-gmux.c:105
error: drivers/platform/x86/apple-gmux.c: patch does not apply
error: Bad exit status from /var/tmp/rpm-tmp.TjXQUq (%prep)

RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.TjXQUq (%prep)
```