### PR TITLE
fix: update APFS patch to match upstream Makefile variable rename

### DIFF
--- a/8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch
+++ b/8002-Necessary-modifications-to-build-APFS-with-the-kerne.patch
@@ -77,9 +77,9 @@ index a2dbed980..bc7bc8cc5 100644
  	  spaceman.o super.o symlink.o transaction.o unicode.o xattr.o xfield.o
 -
 -# If you want mounts to be writable by default, run the build as:
--#   make CONFIG=-DCONFIG_APFS_RW_ALWAYS
+-#   make APFS_CONFIG=-DCONFIG_APFS_RW_ALWAYS
 -# This is risky and not generally recommended.
--ccflags-y += $(CONFIG)
+-ccflags-y += $(APFS_CONFIG)
 -
 -default:
 -	./genver.sh


### PR DESCRIPTION
The upstream linux-apfs-rw module recently renamed the build variable from CONFIG to APFS_CONFIG. This caused the 8002 patch to fail during the kernel prepare phase. Updated the target lines in the patch to correctly match the new variable name, allowing the out-of-tree instructions to be removed and the driver to build successfully in-tree.