### PR TITLE
fix: use iowrite8 for byte-sized MMIO registers in applesmc

### DIFF
--- a/3005-applesmc-basic-mmio-interface-implementation.patch
+++ b/3005-applesmc-basic-mmio-interface-implementation.patch
@@ -102,8 +102,8 @@ index 5442897e3..435541f9f 100644
 +
 +	iomem_clear_status(smc);
 +	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
-+	iowrite32(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
-+	iowrite32(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
 +
 +	if (iomem_wait_read(smc))
 +		return -EIO;
@@ -145,8 +145,8 @@ index 5442897e3..435541f9f 100644
 +
 +	iomem_clear_status(smc);
 +	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
-+	iowrite32(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
-+	iowrite32(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
 +
 +	if (iomem_wait_read(smc))
 +		return -EIO;
@@ -176,9 +176,9 @@ index 5442897e3..435541f9f 100644
 +	iomem_clear_status(smc);
 +	iowrite32(key_int, smc->iomem_base + APPLESMC_IOMEM_KEY_NAME);
 +	memcpy_toio(smc->iomem_base + APPLESMC_IOMEM_KEY_DATA, buffer, len);
-+	iowrite32(len, smc->iomem_base + APPLESMC_IOMEM_KEY_DATA_LEN);
-+	iowrite32(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
-+	iowrite32(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
++	iowrite8(len, smc->iomem_base + APPLESMC_IOMEM_KEY_DATA_LEN);
++	iowrite8(0, smc->iomem_base + APPLESMC_IOMEM_KEY_SMC_ID);
++	iowrite8(cmd, smc->iomem_base + APPLESMC_IOMEM_KEY_CMD);
 +
 +	if (iomem_wait_read(smc))
 +		return -EIO;


### PR DESCRIPTION
## Summary

The `iomem_write_smc`, `iomem_read_smc`, and `iomem_get_smc_key_type` functions in patch 3005 use `iowrite32` to write to byte-sized MMIO registers at non-aligned addresses:

- `KEY_DATA_LEN` at offset `0x7D`
- `KEY_SMC_ID` at offset `0x7E`
- `KEY_CMD` at offset `0x7F`

On some T2 Macs (confirmed on MacBook Air 8,1), the 32-bit writes at these consecutive, non-aligned addresses cause the T2 SMC to receive corrupted command sequences. The write to `0x7D` clobbers `0x7E` (SMC_ID) and `0x7F` (CMD), and the subsequent `iowrite32` to `0x7E` clobbers `0x7F` (CMD) again before the real command is written.

This results in the SMC returning error `0x87` (`SmcKeySizeMismatch`) on every write operation, making fan control via `t2fanrd` completely non-functional — the `F0Md` (fan manual mode) key can never be written.

## Fix

Use `iowrite8` for these byte-sized registers, matching the `ioread8` already used to read them. The 4-byte `KEY_NAME` register at `0x78` correctly remains `iowrite32`.

## Testing

- **Hardware**: MacBook Air 8,1 (T2 chip)
- **Kernel**: 6.18.13 with t2linux patches
- **Before fix**: `write_smc_mmio(11 F0Md) failed: 135` at every boot, `t2fanrd` crash-loops
- **After fix**: `t2fanrd` starts successfully, fan manual mode writes succeed, fan speed control works