### PR TITLE
hwmon/macsmc: fix T2 FS! fan control dead path

### DIFF
--- a/3008-hwmon-macsmc-add-support-for-intel-macs.patch
+++ b/3008-hwmon-macsmc-add-support-for-intel-macs.patch
@@ -6,8 +6,8 @@ Subject: [PATCH 08/12] hwmon/macsmc: add support for intel macs
 Signed-off-by: Atharva Tiwari <atharvatiwarilinuxdev@gmail.com>
 ---
  drivers/hwmon/Kconfig        |   5 +-
- drivers/hwmon/macsmc-hwmon.c | 269 ++++++++++++++++++++++++++++++++++-
- 2 files changed, 264 insertions(+), 10 deletions(-)
+ drivers/hwmon/macsmc-hwmon.c | 281 +++++++++++++++++++++++++++++++++++++-
+ 2 files changed, 272 insertions(+), 14 deletions(-)
 
 diff --git a/drivers/hwmon/Kconfig b/drivers/hwmon/Kconfig
 index 29944e0555a4..cf86e6f0ecec 100644
@@ -85,6 +85,17 @@ index 6764da7ef21d..91726774bdcf 100644
  static int macsmc_hwmon_write_fan(struct device *dev, u32 attr, int channel,
  				  long val)
  {
+@@ -398,7 +418,9 @@ static int macsmc_hwmon_write_fan(struct device *dev, u32 attr, int channel,
+ 	long min, max;
+ 	int ret;
+ 
+-	if (!fan_control || hwmon->fan.fans[channel].mode.macsmc_key == 0)
++	if (!fan_control ||
++	    (hwmon->fan.fans[channel].mode.macsmc_key == 0 &&
++	     !hwmon->fan.has_old_manual))
+ 		return -EOPNOTSUPP;
+ 
+ 	/*
 @@ -417,7 +437,10 @@ static int macsmc_hwmon_write_fan(struct device *dev, u32 attr, int channel,
  	if (val >= min && val <= max) {
  		if (!hwmon->fan.fans[channel].manual) {
@@ -109,6 +120,30 @@ index 6764da7ef21d..91726774bdcf 100644
  						     &hwmon->fan.fans[channel].mode, 0);
  			if (ret < 0)
  				return ret;
+@@ -489,10 +515,11 @@ static int macsmc_hwmon_write(struct device *dev, enum hwmon_sensor_types type,
+ }
+ 
+ static umode_t macsmc_hwmon_fan_is_visible(const struct macsmc_hwmon_fan *fan,
+-					   u32 attr)
++					   u32 attr, bool has_old_manual)
+ {
+ 	if (fan->attrs & BIT(attr)) {
+-		if (attr == hwmon_fan_target && fan_control && fan->mode.macsmc_key)
++		if (attr == hwmon_fan_target && fan_control &&
++		    (fan->mode.macsmc_key || has_old_manual))
+ 			return 0644;
+ 
+ 		return 0444;
+@@ -522,7 +548,8 @@ static umode_t macsmc_hwmon_is_visible(const void *data,
+ 		sensor = &hwmon->temp.sensors[channel];
+ 		break;
+ 	case hwmon_fan:
+-		return macsmc_hwmon_fan_is_visible(&hwmon->fan.fans[channel], attr);
++		return macsmc_hwmon_fan_is_visible(&hwmon->fan.fans[channel], attr,
++						   hwmon->fan.has_old_manual);
+ 	default:
+ 		return 0;
+ 	}
 @@ -592,6 +618,20 @@ static int macsmc_hwmon_create_sensor(struct device *dev, struct apple_smc *smc,
  	return 0;
  }

--- a/3011-power-supply-macsmc-add-support-for-intel-macs.patch
+++ b/3011-power-supply-macsmc-add-support-for-intel-macs.patch
@@ -1,15 +1,15 @@
-From 09e0fe6a5925d7e992cd0219871a8fd89d4d324e Mon Sep 17 00:00:00 2001
+From 019c2c4654925e8d8686c30dba65aefb4eaec490 Mon Sep 17 00:00:00 2001
 From: Atharva Tiwari <atharvatiwarilinuxdev@gmail.com>
 Date: Sat, 25 Apr 2026 19:46:29 +0530
 Subject: [PATCH 11/12] power/supply/macsmc: add support for intel macs
 
 Signed-off-by: Atharva Tiwari <atharvatiwarilinuxdev@gmail.com>
 ---
- drivers/power/supply/macsmc-power.c | 592 ++++++++++++++++++++++------
- 1 file changed, 463 insertions(+), 129 deletions(-)
+ drivers/power/supply/macsmc-power.c | 600 ++++++++++++++++++++++------
+ 1 file changed, 471 insertions(+), 129 deletions(-)
 
 diff --git a/drivers/power/supply/macsmc-power.c b/drivers/power/supply/macsmc-power.c
-index 33ca07460f3a..39efb710d19e 100644
+index 33ca07460f3a..29988508a474 100644
 --- a/drivers/power/supply/macsmc-power.c
 +++ b/drivers/power/supply/macsmc-power.c
 @@ -4,9 +4,11 @@
@@ -33,21 +33,15 @@ index 33ca07460f3a..39efb710d19e 100644
  
  	u8 num_cells;
  	int nominal_voltage_mv;
-@@ -190,6 +193,28 @@ static int macsmc_battery_get_status(struct macsmc_power *power)
+@@ -190,6 +193,36 @@ static int macsmc_battery_get_status(struct macsmc_power *power)
  	return POWER_SUPPLY_STATUS_CHARGING;
  }
  
 +static int macsmc_battery_acpi_get_status(struct macsmc_power *power)
 +{
 +	int ret;
++	u8 vu8;
 +	u16 vu16;
-+
-+	ret = apple_smc_read_u16(power->smc, SMC_KEY(B0TF), &vu16);
-+	if (ret < 0)
-+		return ret;
-+
-+	if (vu16 == 0xFFFF)
-+		return POWER_SUPPLY_STATUS_NOT_CHARGING;
 +
 +	ret = apple_smc_read_u16(power->smc, SMC_KEY(BRSC), &vu16);
 +	if (ret < 0)
@@ -56,13 +50,27 @@ index 33ca07460f3a..39efb710d19e 100644
 +	if (swab16(vu16) == 100)
 +		return POWER_SUPPLY_STATUS_FULL;
 +
++	ret = apple_smc_read_u8(power->smc, SMC_KEY(BCLM), &vu8);
++	if (ret < 0)
++		return ret;
++
++	if (swab16(vu16) >= vu8)
++		return POWER_SUPPLY_STATUS_NOT_CHARGING;
++
++	ret = apple_smc_read_u16(power->smc, SMC_KEY(B0TF), &vu16);
++	if (ret < 0)
++		return ret;
++
++	if (vu16 == 0xFFFF)
++		return POWER_SUPPLY_STATUS_DISCHARGING;
++
 +	return POWER_SUPPLY_STATUS_CHARGING;
 +}
 +
  static int macsmc_battery_get_charge_behaviour(struct macsmc_power *power)
  {
  	int ret;
-@@ -303,6 +328,29 @@ static int macsmc_battery_get_capacity_level(struct macsmc_power *power)
+@@ -303,6 +336,29 @@ static int macsmc_battery_get_capacity_level(struct macsmc_power *power)
  		return POWER_SUPPLY_CAPACITY_LEVEL_NORMAL;
  }
  
@@ -92,7 +100,7 @@ index 33ca07460f3a..39efb710d19e 100644
  static int macsmc_battery_get_property(struct power_supply *psy,
  				       enum power_supply_property psp,
  				       union power_supply_propval *val)
-@@ -316,9 +364,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -316,9 +372,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  	s64 vs64;
  	bool flag;
  
@@ -107,7 +115,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		ret = val->intval < 0 ? val->intval : 0;
  		break;
  	case POWER_SUPPLY_PROP_PRESENT:
-@@ -334,31 +386,53 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -334,31 +394,53 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_TIME_TO_FULL_NOW:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0TF), &vu16);
@@ -169,7 +177,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_VOLTAGE_MAX_DESIGN:
  		/* Calculate total max design voltage from per-cell maximum voltage */
-@@ -381,11 +455,17 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -381,11 +463,17 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT_MAX:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0RI), &vu16);
@@ -189,7 +197,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_FULL_DESIGN:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0DC), &vu16);
-@@ -393,7 +473,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -393,7 +481,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_FULL:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0FC), &vu16);
@@ -201,7 +209,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_NOW:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0RM), &vu16);
-@@ -414,8 +497,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -414,8 +505,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		val->intval = (s16)swab16(vu16) * power->nominal_voltage_mv;
  		break;
  	case POWER_SUPPLY_PROP_TEMP:
@@ -217,7 +225,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_COUNTER:
  		ret = apple_smc_read_s64(power->smc, SMC_KEY(BAAC), &vs64);
-@@ -423,7 +511,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -423,7 +519,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_CYCLE_COUNT:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0CT), &vu16);
@@ -229,7 +237,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_SCOPE:
  		val->intval = POWER_SUPPLY_SCOPE_SYSTEM;
-@@ -450,6 +541,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -450,6 +549,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  	case POWER_SUPPLY_PROP_MANUFACTURE_DAY:
  		ret = macsmc_battery_get_date(&power->mfg_date[4], &val->intval);
  		break;
@@ -240,7 +248,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	default:
  		return -EINVAL;
  	}
-@@ -466,6 +561,10 @@ static int macsmc_battery_set_property(struct power_supply *psy,
+@@ -466,6 +569,10 @@ static int macsmc_battery_set_property(struct power_supply *psy,
  	switch (psp) {
  	case POWER_SUPPLY_PROP_CHARGE_BEHAVIOUR:
  		return macsmc_battery_set_charge_behaviour(power, val->intval);
@@ -251,7 +259,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	default:
  		return -EINVAL;
  	}
-@@ -477,6 +576,8 @@ static int macsmc_battery_property_is_writeable(struct power_supply *psy,
+@@ -477,6 +584,8 @@ static int macsmc_battery_property_is_writeable(struct power_supply *psy,
  	switch (psp) {
  	case POWER_SUPPLY_PROP_CHARGE_BEHAVIOUR:
  		return true;
@@ -260,7 +268,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	default:
  		return false;
  	}
-@@ -489,24 +590,204 @@ static const struct power_supply_desc macsmc_battery_desc_template = {
+@@ -489,24 +598,204 @@ static const struct power_supply_desc macsmc_battery_desc_template = {
  	.set_property		= macsmc_battery_set_property,
  	.property_is_writeable	= macsmc_battery_property_is_writeable,
  };
@@ -333,11 +341,11 @@ index 33ca07460f3a..39efb710d19e 100644
 +		ret = apple_smc_read_u16(smc, key, &fp3d);
 +		if (ret)
 +			return ret;
-+
+ 
 +		*val = mult_frac(cpu_to_be16(fp3d), scale, BIT(13));
 +		break;
 +	}
- 
++
 +	/* 5.11 fixed point decimal */
 +	case __SMC_KEY('f', 'p', '5', 'b'): {
 +		u16 fp5b;
@@ -469,7 +477,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_INPUT_CURRENT_LIMIT:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(AC-i), &vu16);
-@@ -645,15 +926,29 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -645,15 +934,29 @@ static int macsmc_power_probe(struct platform_device *pdev)
  	/*
  	 * Check for battery presence.
  	 * B0AV is a fundamental key.
@@ -502,7 +510,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	if (apple_smc_key_exists(smc, SMC_KEY(CHIS)))
  		has_ac_adapter = true;
  
-@@ -670,104 +965,126 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -670,104 +973,126 @@ static int macsmc_power_probe(struct platform_device *pdev)
  
  		nprops = 0;
  
@@ -719,7 +727,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		psy_cfg.drv_data = power;
  		power->batt = devm_power_supply_register(dev, &power->batt_desc, &psy_cfg);
  		if (IS_ERR(power->batt)) {
-@@ -788,19 +1105,28 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -788,19 +1113,28 @@ static int macsmc_power_probe(struct platform_device *pdev)
  
  		nprops = 0;
  
@@ -760,7 +768,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		if (nprops > MACSMC_MAX_AC_PROPS)
  			return -ENOMEM;
  
-@@ -820,9 +1146,12 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -820,9 +1154,12 @@ static int macsmc_power_probe(struct platform_device *pdev)
  	if (!power->batt && !power->ac)
  		return -ENODEV;
  
@@ -775,7 +783,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	return 0;
  }
  
-@@ -830,9 +1159,13 @@ static void macsmc_power_remove(struct platform_device *pdev)
+@@ -830,9 +1167,13 @@ static void macsmc_power_remove(struct platform_device *pdev)
  {
  	struct macsmc_power *power = dev_get_drvdata(&pdev->dev);
  
@@ -791,7 +799,7 @@ index 33ca07460f3a..39efb710d19e 100644
  static const struct platform_device_id macsmc_power_id[] = {
  	{ "macsmc-power" },
  	{ /* sentinel */ }
-@@ -853,3 +1186,4 @@ MODULE_LICENSE("Dual MIT/GPL");
+@@ -853,3 +1194,4 @@ MODULE_LICENSE("Dual MIT/GPL");
  MODULE_DESCRIPTION("Apple SMC battery and power management driver");
  MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
  MODULE_AUTHOR("Michael Reeves <michael.reeves077@gmail.com>");


### PR DESCRIPTION
Fixes a regression in 3008-hwmon-macsmc-add-support-for-intel-macs.patch
affecting T2 Macs (e.g. MacBookPro16,1).

Issue:
- fan*_target is read-only (0444)
- write_fan returns -EOPNOTSUPP
- FS! legacy fan control path is unreachable

Cause:
T2 Macs do not expose per-fan F<n>Md keys, so
fan->mode.macsmc_key is 0 even though FS! (has_old_manual) exists.

Fix:
- allow has_old_manual in write_fan guard
- allow has_old_manual in fan_is_visible
- pass has_old_manual through visibility path

Tested on Ubuntu 24.04 (Noble) using linux-t2 7.1.0-3-t2-noble kernel on MacBookPro16,1 
- fan*_target: 0444 → 0644
- echo 5000 > fan1_target works
- fan RPM increases to ~4600 RPM