### PR TITLE
fix: endianess issue when reading rtc, resulting in random time read close to epoch

### DIFF
--- a/3009-rtc-macsmc-add-x86-support.patch
+++ b/3009-rtc-macsmc-add-x86-support.patch
@@ -3,31 +3,103 @@ From: Atharva Tiwari <atharvatiwarilinuxdev@gmail.com>
 Date: Fri, 24 Apr 2026 23:58:47 +0530
 Subject: [PATCH 09/12] rtc/macsmc: add x86 support
 
+The ACPI SMC backend returns CLKM and CLKO as raw 6-byte
+little-endian buffers. The existing code copies them directly into
+the low bytes of a u64 via memcpy, which produces correct results
+on little-endian hosts but is not portable and cannot work when
+the ACPI path reads the offset from the SMC key (CLKO) instead of
+NVMEM.
+
+Add explicit LE48 serialization helpers for the ACPI path. The
+Apple Silicon / NVMEM code path is left completely unchanged.
+
+Also guard the probe so the driver loads on x86 machines with an
+ACPI SMC that exposes the CLKM key, and skip the NVMEM rtc_offset
+cell which does not exist on Intel Macs.
+
 Signed-off-by: Atharva Tiwari <atharvatiwarilinuxdev@gmail.com>
 ---
- drivers/rtc/rtc-macsmc.c | 45 ++++++++++++++++++++++++++--------------
- 1 file changed, 30 insertions(+), 15 deletions(-)
+ drivers/rtc/rtc-macsmc.c | 111 +++++++++++++++++++++++++++++++++++-----------
+ 1 file changed, 84 insertions(+), 27 deletions(-)
 
 diff --git a/drivers/rtc/rtc-macsmc.c b/drivers/rtc/rtc-macsmc.c
 index 8fe883066956..0cf24f0f7963 100644
 --- a/drivers/rtc/rtc-macsmc.c
 +++ b/drivers/rtc/rtc-macsmc.c
-@@ -42,17 +42,24 @@ static int macsmc_rtc_get_time(struct device *dev, struct rtc_time *tm)
- 	if (ret != RTC_BYTES)
- 		return -EIO;
+@@ -26,6 +26,26 @@ struct macsmc_rtc {
+ 	struct rtc_device *rtc_dev;
+ 	struct nvmem_cell *rtc_offset;
+ };
++
++static u64 macsmc_rtc_get_le48(const u8 buf[RTC_BYTES])
++{
++	return ((u64)buf[0]) |
++	       ((u64)buf[1] << 8) |
++	       ((u64)buf[2] << 16) |
++	       ((u64)buf[3] << 24) |
++	       ((u64)buf[4] << 32) |
++	       ((u64)buf[5] << 40);
++}
++
++static void macsmc_rtc_put_le48(u8 buf[RTC_BYTES], u64 val)
++{
++	buf[0] = val;
++	buf[1] = val >> 8;
++	buf[2] = val >> 16;
++	buf[3] = val >> 24;
++	buf[4] = val >> 32;
++	buf[5] = val >> 40;
++}
  
--	p_off = nvmem_cell_read(rtc->rtc_offset, &len);
--	if (IS_ERR(p_off))
--		return PTR_ERR(p_off);
--	if (len < RTC_BYTES) {
+ static int macsmc_rtc_get_time(struct device *dev, struct rtc_time *tm)
+ {
+@@ -32,27 +52,44 @@ static int macsmc_rtc_get_time(struct device *dev, struct rtc_time *tm)
+ 	struct macsmc_rtc *rtc = dev_get_drvdata(dev);
+ 	u64 ctr = 0, off = 0;
+ 	time64_t now;
+ 	void *p_off;
++	u8 buf[RTC_BYTES];
+ 	size_t len;
+ 	int ret;
+ 
+-	ret = apple_smc_read(rtc->smc, SMC_KEY(CLKM), &ctr, RTC_BYTES);
+-	if (ret < 0)
+-		return ret;
+-	if (ret != RTC_BYTES)
+-		return -EIO;
+-
 +	if (rtc->smc->is_acpi) {
-+		ret = apple_smc_read(rtc->smc, SMC_KEY(CLKO), &off, RTC_BYTES);
++		ret = apple_smc_read(rtc->smc, SMC_KEY(CLKM), buf, RTC_BYTES);
 +		if (ret < 0)
 +			return ret;
 +		if (ret != RTC_BYTES)
 +			return -EIO;
++		ctr = macsmc_rtc_get_le48(buf);
++
++		ret = apple_smc_read(rtc->smc, SMC_KEY(CLKO), buf, RTC_BYTES);
++		if (ret < 0)
++			return ret;
++		if (ret != RTC_BYTES)
++			return -EIO;
++		off = macsmc_rtc_get_le48(buf);
 +	} else {
++		ret = apple_smc_read(rtc->smc, SMC_KEY(CLKM), &ctr, RTC_BYTES);
++		if (ret < 0)
++			return ret;
++		if (ret != RTC_BYTES)
++			return -EIO;
++
+-	p_off = nvmem_cell_read(rtc->rtc_offset, &len);
 +		p_off = nvmem_cell_read(rtc->rtc_offset, &len);
+-	if (IS_ERR(p_off))
+-		return PTR_ERR(p_off);
+-	if (len < RTC_BYTES) {
+-		kfree(p_off);
+-		return -EIO;
+-	}
+-
+-	memcpy(&off, p_off, RTC_BYTES);
+-	kfree(p_off);
 +		if (IS_ERR(p_off))
 +			return PTR_ERR(p_off);
 +		if (len < RTC_BYTES) {
@@ -36,27 +108,50 @@ index 8fe883066956..0cf24f0f7963 100644
 +		}
 +
 +		memcpy(&off, p_off, RTC_BYTES);
- 		kfree(p_off);
--		return -EIO;
- 	}
--
--	memcpy(&off, p_off, RTC_BYTES);
--	kfree(p_off);
--
++		kfree(p_off);
++	}
+ 
  	/* Sign extend from 48 to 64 bits, then arithmetic shift right 15 bits to get seconds */
  	now = sign_extend64(ctr + off, RTC_BITS - 1) >> RTC_SEC_SHIFT;
  	rtc_time64_to_tm(now, tm);
-@@ -74,6 +81,9 @@ static int macsmc_rtc_set_time(struct device *dev, struct rtc_time *tm)
+@@ -63,16 +100,31 @@ static int macsmc_rtc_set_time(struct device *dev, struct rtc_time *tm)
+ {
+ 	struct macsmc_rtc *rtc = dev_get_drvdata(dev);
+ 	u64 ctr = 0, off = 0;
++	u8 buf[RTC_BYTES];
+ 	int ret;
+ 
+-	ret = apple_smc_read(rtc->smc, SMC_KEY(CLKM), &ctr, RTC_BYTES);
+-	if (ret < 0)
+-		return ret;
+-	if (ret != RTC_BYTES)
+-		return -EIO;
++	if (rtc->smc->is_acpi) {
++		ret = apple_smc_read(rtc->smc, SMC_KEY(CLKM), buf, RTC_BYTES);
++		if (ret < 0)
++			return ret;
++		if (ret != RTC_BYTES)
++			return -EIO;
++		ctr = macsmc_rtc_get_le48(buf);
++	} else {
++		ret = apple_smc_read(rtc->smc, SMC_KEY(CLKM), &ctr, RTC_BYTES);
++		if (ret < 0)
++			return ret;
++		if (ret != RTC_BYTES)
++			return -EIO;
++	}
  
  	/* This sets the offset such that the set second begins now */
  	off = (rtc_tm_to_time64(tm) << RTC_SEC_SHIFT) - ctr;
-+	if (rtc->smc->is_acpi)
-+		return apple_smc_write(rtc->smc, SMC_KEY(CLKO), &off, RTC_BYTES);
++	if (rtc->smc->is_acpi) {
++		macsmc_rtc_put_le48(buf, off);
++		return apple_smc_write(rtc->smc, SMC_KEY(CLKO), buf, RTC_BYTES);
++	}
 +
  	return nvmem_cell_write(rtc->rtc_offset, &off, RTC_BYTES);
  }
  
-@@ -92,7 +102,10 @@ static int macsmc_rtc_probe(struct platform_device *pdev)
+@@ -92,7 +144,10 @@ static int macsmc_rtc_probe(struct platform_device *pdev)
  	 * thus bail out early if the SMC on the current machines does not
  	 * support RTC and has no node in the device tree.
  	 */
@@ -68,7 +163,7 @@ index 8fe883066956..0cf24f0f7963 100644
  		return -ENODEV;
  
  	rtc = devm_kzalloc(&pdev->dev, sizeof(*rtc), GFP_KERNEL);
-@@ -102,11 +115,12 @@ static int macsmc_rtc_probe(struct platform_device *pdev)
+@@ -102,11 +157,12 @@ static int macsmc_rtc_probe(struct platform_device *pdev)
  	rtc->dev = &pdev->dev;
  	rtc->smc = smc;
  
@@ -86,11 +181,10 @@ index 8fe883066956..0cf24f0f7963 100644
  	rtc->rtc_dev = devm_rtc_allocate_device(&pdev->dev);
  	if (IS_ERR(rtc->rtc_dev))
  		return PTR_ERR(rtc->rtc_dev);
-@@ -138,3 +152,4 @@ module_platform_driver(macsmc_rtc_driver);
+@@ -138,3 +194,4 @@ module_platform_driver(macsmc_rtc_driver);
  MODULE_LICENSE("Dual MIT/GPL");
  MODULE_DESCRIPTION("Apple SMC RTC driver");
  MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
 +MODULE_ALIAS("platform:macsmc-rtc");
 -- 
 2.43.0
-

--- a/3011-power-supply-macsmc-add-support-for-intel-macs.patch
+++ b/3011-power-supply-macsmc-add-support-for-intel-macs.patch
@@ -1,15 +1,15 @@
-From 09e0fe6a5925d7e992cd0219871a8fd89d4d324e Mon Sep 17 00:00:00 2001
+From 07bbe2ceae5705ae6b7fdfb014e6197ae3a26b54 Mon Sep 17 00:00:00 2001
 From: Atharva Tiwari <atharvatiwarilinuxdev@gmail.com>
 Date: Sat, 25 Apr 2026 19:46:29 +0530
 Subject: [PATCH 11/12] power/supply/macsmc: add support for intel macs
 
 Signed-off-by: Atharva Tiwari <atharvatiwarilinuxdev@gmail.com>
 ---
- drivers/power/supply/macsmc-power.c | 592 ++++++++++++++++++++++------
- 1 file changed, 463 insertions(+), 129 deletions(-)
+ drivers/power/supply/macsmc-power.c | 602 ++++++++++++++++++++++------
+ 1 file changed, 473 insertions(+), 129 deletions(-)
 
 diff --git a/drivers/power/supply/macsmc-power.c b/drivers/power/supply/macsmc-power.c
-index 33ca07460f3a..39efb710d19e 100644
+index 33ca07460f3a..3f113522e2fd 100644
 --- a/drivers/power/supply/macsmc-power.c
 +++ b/drivers/power/supply/macsmc-power.c
 @@ -4,9 +4,11 @@
@@ -33,36 +33,38 @@ index 33ca07460f3a..39efb710d19e 100644
  
  	u8 num_cells;
  	int nominal_voltage_mv;
-@@ -190,6 +193,28 @@ static int macsmc_battery_get_status(struct macsmc_power *power)
+@@ -190,6 +193,30 @@ static int macsmc_battery_get_status(struct macsmc_power *power)
  	return POWER_SUPPLY_STATUS_CHARGING;
  }
  
 +static int macsmc_battery_acpi_get_status(struct macsmc_power *power)
 +{
 +	int ret;
-+	u16 vu16;
++	u8 vu8;
 +
-+	ret = apple_smc_read_u16(power->smc, SMC_KEY(B0TF), &vu16);
++	ret = apple_smc_read_u8(power->smc, SMC_KEY(BNCR), &vu8);
 +	if (ret < 0)
 +		return ret;
 +
-+	if (vu16 == 0xFFFF)
-+		return POWER_SUPPLY_STATUS_NOT_CHARGING;
-+
-+	ret = apple_smc_read_u16(power->smc, SMC_KEY(BRSC), &vu16);
-+	if (ret < 0)
-+		return ret;
-+
-+	if (swab16(vu16) == 100)
++	switch (vu8) {
++	/* Battery Charging */
++	case 0:
++		return POWER_SUPPLY_STATUS_CHARGING;
++	/* AC Adapter Not Connected */
++	case 1:
++		return POWER_SUPPLY_STATUS_DISCHARGING;
++	/* Battery Full */
++	case 4:
 +		return POWER_SUPPLY_STATUS_FULL;
-+
-+	return POWER_SUPPLY_STATUS_CHARGING;
++	default:
++		return POWER_SUPPLY_STATUS_NOT_CHARGING;
++	}
 +}
 +
  static int macsmc_battery_get_charge_behaviour(struct macsmc_power *power)
  {
  	int ret;
-@@ -303,6 +328,29 @@ static int macsmc_battery_get_capacity_level(struct macsmc_power *power)
+@@ -303,6 +330,29 @@ static int macsmc_battery_get_capacity_level(struct macsmc_power *power)
  		return POWER_SUPPLY_CAPACITY_LEVEL_NORMAL;
  }
  
@@ -92,7 +94,7 @@ index 33ca07460f3a..39efb710d19e 100644
  static int macsmc_battery_get_property(struct power_supply *psy,
  				       enum power_supply_property psp,
  				       union power_supply_propval *val)
-@@ -316,9 +364,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -316,9 +366,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  	s64 vs64;
  	bool flag;
  
@@ -107,7 +109,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		ret = val->intval < 0 ? val->intval : 0;
  		break;
  	case POWER_SUPPLY_PROP_PRESENT:
-@@ -334,31 +386,53 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -334,31 +388,53 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_TIME_TO_FULL_NOW:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0TF), &vu16);
@@ -169,7 +171,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_VOLTAGE_MAX_DESIGN:
  		/* Calculate total max design voltage from per-cell maximum voltage */
-@@ -381,11 +455,17 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -381,11 +457,17 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_CONSTANT_CHARGE_CURRENT_MAX:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0RI), &vu16);
@@ -189,7 +191,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_FULL_DESIGN:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0DC), &vu16);
-@@ -393,7 +473,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -393,7 +475,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_FULL:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0FC), &vu16);
@@ -201,7 +203,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_NOW:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0RM), &vu16);
-@@ -414,8 +497,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -414,8 +499,13 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		val->intval = (s16)swab16(vu16) * power->nominal_voltage_mv;
  		break;
  	case POWER_SUPPLY_PROP_TEMP:
@@ -217,7 +219,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_CHARGE_COUNTER:
  		ret = apple_smc_read_s64(power->smc, SMC_KEY(BAAC), &vs64);
-@@ -423,7 +511,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -423,7 +513,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  		break;
  	case POWER_SUPPLY_PROP_CYCLE_COUNT:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(B0CT), &vu16);
@@ -229,7 +231,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_SCOPE:
  		val->intval = POWER_SUPPLY_SCOPE_SYSTEM;
-@@ -450,6 +541,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
+@@ -450,6 +543,10 @@ static int macsmc_battery_get_property(struct power_supply *psy,
  	case POWER_SUPPLY_PROP_MANUFACTURE_DAY:
  		ret = macsmc_battery_get_date(&power->mfg_date[4], &val->intval);
  		break;
@@ -240,7 +242,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	default:
  		return -EINVAL;
  	}
-@@ -466,6 +561,10 @@ static int macsmc_battery_set_property(struct power_supply *psy,
+@@ -466,6 +563,10 @@ static int macsmc_battery_set_property(struct power_supply *psy,
  	switch (psp) {
  	case POWER_SUPPLY_PROP_CHARGE_BEHAVIOUR:
  		return macsmc_battery_set_charge_behaviour(power, val->intval);
@@ -251,7 +253,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	default:
  		return -EINVAL;
  	}
-@@ -477,6 +576,8 @@ static int macsmc_battery_property_is_writeable(struct power_supply *psy,
+@@ -477,6 +578,8 @@ static int macsmc_battery_property_is_writeable(struct power_supply *psy,
  	switch (psp) {
  	case POWER_SUPPLY_PROP_CHARGE_BEHAVIOUR:
  		return true;
@@ -260,44 +262,45 @@ index 33ca07460f3a..39efb710d19e 100644
  	default:
  		return false;
  	}
-@@ -489,24 +590,204 @@ static const struct power_supply_desc macsmc_battery_desc_template = {
- 	.set_property		= macsmc_battery_set_property,
+@@ -490,23 +593,211 @@ static const struct power_supply_desc macsmc_battery_desc_template = {
  	.property_is_writeable	= macsmc_battery_property_is_writeable,
  };
+ 
 +static int macsmc_ac_read_f32_scaled(struct apple_smc *smc, smc_key key,
-+                                        int *p, int scale)
++				     int *p, int scale)
 +{
-+	u32 fval, val;
++	u32 fval;
++	u64 val;
 +	int ret, exp;
 +
 +	ret = apple_smc_read_u32(smc, key, &fval);
 +	if (ret < 0)
 +		return ret;
 +
-+	val = ((u32)((fval & GENMASK(22, 0)) | BIT(23)));
++	val = (u64)((fval & GENMASK(22, 0)) | BIT(23));
 +	exp = ((fval >> 23) & 0xff) - 127 - 23;
 +
-+	/* We never have negatively scaled SMC floats */
-+	val *= scale;
++	val *= (u64)scale;
 +
-+	if (exp > 31)
-+		val = U32_MAX;
-+	else if (exp < -31)
++	if (exp > 63)
++		val = U64_MAX;
++	else if (exp < -63)
 +		val = 0;
 +	else if (exp < 0)
 +		val >>= -exp;
-+	else if (exp != 0 && (val & ~((1ULL << (32 - exp)) - 1))) /* overflow */
-+		val = U32_MAX;
++	else if (exp != 0 &&
++		 (val & ~((1ULL << (64 - exp)) - 1)))
++		val = U64_MAX;
 +	else
 +		val <<= exp;
 +
 +	if (fval & BIT(31)) {
-+		if (val > (u32)INT_MAX + 1)
++		if (val > (u64)INT_MAX + 1)
 +			*p = INT_MIN;
 +		else
 +			*p = -(int)val;
 +	} else {
-+		if (val > (u32)INT_MAX)
++		if (val > INT_MAX)
 +			*p = INT_MAX;
 +		else
 +			*p = (int)val;
@@ -306,7 +309,9 @@ index 33ca07460f3a..39efb710d19e 100644
 +	return 0;
 +}
 +
-+static int macsmc_ac_read(struct apple_smc *smc, smc_key key, int *val, int scale) {
++static int macsmc_ac_read(struct apple_smc *smc, smc_key key, int *val,
++			  int scale)
++{
 +	int ret;
 +	struct apple_smc_key_info info;
 +
@@ -326,6 +331,7 @@ index 33ca07460f3a..39efb710d19e 100644
 +		*val = flt_;
 +		break;
 +	}
++
 +	/* 3.13 fixed point decimal */
 +	case __SMC_KEY('f', 'p', '3', 'd'): {
 +		u16 fp3d;
@@ -337,7 +343,7 @@ index 33ca07460f3a..39efb710d19e 100644
 +		*val = mult_frac(cpu_to_be16(fp3d), scale, BIT(13));
 +		break;
 +	}
- 
++
 +	/* 5.11 fixed point decimal */
 +	case __SMC_KEY('f', 'p', '5', 'b'): {
 +		u16 fp5b;
@@ -361,6 +367,7 @@ index 33ca07460f3a..39efb710d19e 100644
 +		*val = mult_frac(cpu_to_be16(fp88), scale, BIT(8));
 +		break;
 +	}
++
 +	/* 3.12 signed fixed point decimal */
 +	case __SMC_KEY('s', 'p', '3', 'c'): {
 +		s16 sp3c;
@@ -420,19 +427,21 @@ index 33ca07460f3a..39efb710d19e 100644
 +		*val = mult_frac((s16)cpu_to_be16(sp78), scale, BIT(8));
 +		break;
 +	}
++
 +	default:
 +		return -EOPNOTSUPP;
 +	}
 +
 +	return 0;
 +}
++
  static int macsmc_ac_get_property(struct power_supply *psy,
  				  enum power_supply_property psp,
  				  union power_supply_propval *val)
  {
  	struct macsmc_power *power = power_supply_get_drvdata(psy);
  	int ret = 0;
-+	int vs32;
++	u8 vu8;
  	u16 vu16;
  	u32 vu32;
  
@@ -441,15 +450,15 @@ index 33ca07460f3a..39efb710d19e 100644
 -		ret = apple_smc_read_u32(power->smc, SMC_KEY(CHIS), &vu32);
 -		val->intval = !!vu32;
 +		if (power->smc->is_acpi) {
-+			ret = macsmc_ac_read(power->smc, SMC_KEY(ID0R), &vs32, 1);
-+			val->intval = !!vs32;
++			ret = apple_smc_read_u8(power->smc, SMC_KEY(BNCR), &vu8);
++			val->intval = vu8 == 1 ? 0 : 1;
 +		} else {
 +			ret = apple_smc_read_u32(power->smc, SMC_KEY(CHIS), &vu32);
 +			val->intval = !!vu32;
 +		}
 +		break;
 +	case POWER_SUPPLY_PROP_CURRENT_NOW:
-+		ret = macsmc_ac_read(power->smc, SMC_KEY(ID0R), &val->intval, 1000);
++		ret = macsmc_ac_read(power->smc, SMC_KEY(ID0R), &val->intval, 1000000);
 +		break;
 +	case POWER_SUPPLY_PROP_POWER_NOW:
 +		if (power->has_pd0r)
@@ -461,7 +470,7 @@ index 33ca07460f3a..39efb710d19e 100644
 -		ret = apple_smc_read_u16(power->smc, SMC_KEY(AC-n), &vu16);
 -		val->intval = vu16 * 1000;
 +		if (power->smc->is_acpi)
-+			ret = macsmc_ac_read(power->smc, SMC_KEY(VD0R), &val->intval, 1000);
++			ret = macsmc_ac_read(power->smc, SMC_KEY(VD0R), &val->intval, 1000000);
 +		else {
 +			ret = apple_smc_read_u16(power->smc, SMC_KEY(AC-n), &vu16);
 +			val->intval = vu16 * 1000;
@@ -469,7 +478,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		break;
  	case POWER_SUPPLY_PROP_INPUT_CURRENT_LIMIT:
  		ret = apple_smc_read_u16(power->smc, SMC_KEY(AC-i), &vu16);
-@@ -645,15 +926,29 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -645,15 +936,29 @@ static int macsmc_power_probe(struct platform_device *pdev)
  	/*
  	 * Check for battery presence.
  	 * B0AV is a fundamental key.
@@ -502,7 +511,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	if (apple_smc_key_exists(smc, SMC_KEY(CHIS)))
  		has_ac_adapter = true;
  
-@@ -670,104 +965,126 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -670,104 +975,126 @@ static int macsmc_power_probe(struct platform_device *pdev)
  
  		nprops = 0;
  
@@ -719,7 +728,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		psy_cfg.drv_data = power;
  		power->batt = devm_power_supply_register(dev, &power->batt_desc, &psy_cfg);
  		if (IS_ERR(power->batt)) {
-@@ -788,19 +1105,28 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -788,19 +1115,28 @@ static int macsmc_power_probe(struct platform_device *pdev)
  
  		nprops = 0;
  
@@ -760,7 +769,7 @@ index 33ca07460f3a..39efb710d19e 100644
  		if (nprops > MACSMC_MAX_AC_PROPS)
  			return -ENOMEM;
  
-@@ -820,9 +1146,12 @@ static int macsmc_power_probe(struct platform_device *pdev)
+@@ -820,9 +1156,12 @@ static int macsmc_power_probe(struct platform_device *pdev)
  	if (!power->batt && !power->ac)
  		return -ENODEV;
  
@@ -775,7 +784,7 @@ index 33ca07460f3a..39efb710d19e 100644
  	return 0;
  }
  
-@@ -830,9 +1159,13 @@ static void macsmc_power_remove(struct platform_device *pdev)
+@@ -830,9 +1169,13 @@ static void macsmc_power_remove(struct platform_device *pdev)
  {
  	struct macsmc_power *power = dev_get_drvdata(&pdev->dev);
  
@@ -791,7 +800,7 @@ index 33ca07460f3a..39efb710d19e 100644
  static const struct platform_device_id macsmc_power_id[] = {
  	{ "macsmc-power" },
  	{ /* sentinel */ }
-@@ -853,3 +1186,4 @@ MODULE_LICENSE("Dual MIT/GPL");
+@@ -853,3 +1196,4 @@ MODULE_LICENSE("Dual MIT/GPL");
  MODULE_DESCRIPTION("Apple SMC battery and power management driver");
  MODULE_AUTHOR("Hector Martin <marcan@marcan.st>");
  MODULE_AUTHOR("Michael Reeves <michael.reeves077@gmail.com>");


### PR DESCRIPTION
Fixes a issue related to timestamps in reality being presented as LE48 on intel mbp x86.

Verified locally on a intel mbp 2019 15" by building the driver alone with the patches applied. 