### PR TITLE
apple-bce: fix scheduling while atomic and playback timestamp

### DIFF
--- a/1001-Add-apple-bce-driver.patch
+++ b/1001-Add-apple-bce-driver.patch
@@ -1360,7 +1360,7 @@ new file mode 100644
 index 000000000..ebbfaa116
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/audio.h
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,126 @@
 +#ifndef AAUDIO_H
 +#define AAUDIO_H
 +
@@ -1446,6 +1446,7 @@ index 000000000..ebbfaa116
 +    bool is_pcm;
 +    struct snd_pcm *pcm;
 +    struct snd_jack *jack;
++    struct work_struct stop_work;
 +};
 +struct aaudio_alsa_pcm_id_mapping {
 +    const char *name;
@@ -1539,9 +1540,10 @@ new file mode 100644
 index 000000000..1026e10a9
 --- /dev/null
 +++ b/drivers/staging/apple-bce/audio/pcm.c
-@@ -0,0 +1,308 @@
+@@ -0,0 +1,320 @@
 +#include "pcm.h"
 +#include "audio.h"
++#include <linux/workqueue.h>
 +
 +static u64 aaudio_get_alsa_fmtbit(struct aaudio_apple_description *desc)
 +{
@@ -1720,23 +1722,29 @@ index 000000000..1026e10a9
 +    pr_debug("aaudio: Started the audio device in %lluns\n", ktime_to_ns(time_end - time_start));
 +}
 +
++static void aaudio_pcm_stop_work(struct work_struct *work)
++{
++    struct aaudio_subdevice *sdev = container_of(work, struct aaudio_subdevice, stop_work);
++    aaudio_cmd_stop_io(sdev->a, sdev->dev_id);
++}
++
 +static int aaudio_pcm_trigger(struct snd_pcm_substream *substream, int cmd)
 +{
 +    struct aaudio_subdevice *sdev = snd_pcm_substream_chip(substream);
 +    struct aaudio_stream *stream = aaudio_pcm_stream(substream);
 +    pr_debug("aaudio_pcm_trigger %x\n", cmd);
 +
-+    /* We only supports triggers on the #0 buffer */
 +    if (substream->number != 0)
 +        return 0;
 +    switch (cmd) {
 +        case SNDRV_PCM_TRIGGER_START:
++            cancel_work_sync(&sdev->stop_work);
 +            aaudio_pcm_start(substream);
 +            stream->started = 1;
 +            break;
 +        case SNDRV_PCM_TRIGGER_STOP:
-+            aaudio_cmd_stop_io(sdev->a, sdev->dev_id);
 +            stream->started = 0;
++            schedule_work(&sdev->stop_work);
 +            break;
 +        default:
 +            return -EINVAL;
@@ -1807,6 +1815,7 @@ index 000000000..1026e10a9
 +    }
 +    if (!id_mapping->name)
 +        sdev->alsa_id = sdev->a->next_alsa_id++;
++    INIT_WORK(&sdev->stop_work, aaudio_pcm_stop_work);
 +    err = snd_pcm_new(sdev->a->card, sdev->uid, sdev->alsa_id,
 +            (int) sdev->out_stream_cnt, (int) sdev->in_stream_cnt, &pcm);
 +    if (err < 0)

--- a/1001-Add-apple-bce-driver.patch
+++ b/1001-Add-apple-bce-driver.patch
@@ -1827,6 +1827,10 @@ index 000000000..1026e10a9
 +
 +    stream = aaudio_pcm_stream(substream);
 +    snd_pcm_stream_lock_irqsave(substream, flags);
++    if (!stream->started) {
++        snd_pcm_stream_unlock_irqrestore(substream, flags);
++        return;
++    }
 +    stream->remote_timestamp = timestamp;
 +    if (stream->waiting_for_first_ts) {
 +        stream->waiting_for_first_ts = false;
@@ -1843,7 +1847,7 @@ index 000000000..1026e10a9
 +
 +    substream = sdev->pcm->streams[SNDRV_PCM_STREAM_PLAYBACK].substream;
 +    if (substream)
-+        aaudio_handle_stream_timestamp(substream, dev_timestamp);
++        aaudio_handle_stream_timestamp(substream, os_timestamp);
 +    substream = sdev->pcm->streams[SNDRV_PCM_STREAM_CAPTURE].substream;
 +    if (substream)
 +        aaudio_handle_stream_timestamp(substream, os_timestamp);


### PR DESCRIPTION
Syncs the bundled apple-bce driver with fixes from [t2linux/apple-bce-drv#31](https://github.com/t2linux/apple-bce-drv/pull/31).

## Fix 1: skip period_elapsed for streams that are not started

**Symptom:** Connecting speakers or headphones to the 3.5mm jack causes `BUG: scheduling while atomic` in `irq/bce_dma`, followed by a flood of `aaudio_pcm_pointer while not started` messages. System becomes unresponsive for audio.

**Cause:** The T2 chip sends timestamp events for all registered audio devices continuously, even when no ALSA stream is open. `aaudio_handle_stream_timestamp()` was unconditionally calling `snd_pcm_period_elapsed()`, which on a stopped stream chains into `snd_pcm_do_stop` → `aaudio_pcm_trigger(STOP)` → `wait_for_completion_timeout()`. The BCE DMA IRQ handler runs with BHs disabled, so any attempt to sleep triggers the bug.

**Fix:** Return early when `stream->started == 0`, matching the guard already in `aaudio_pcm_pointer()`.

## Fix 2: use os_timestamp for PLAYBACK

**Cause:** `aaudio_handle_timestamp()` was passing `dev_timestamp` (T2 clock domain) to the PLAYBACK substream while CAPTURE correctly used `os_timestamp`. After suspend/resume or module re-probe the T2 clock drifts, causing wild PCM positions and XRUNs.

**Fix:** Use `os_timestamp` for both PLAYBACK and CAPTURE.

## Tested

MacBookPro16,1, kernel 7.0.12-arch1-Watanare-T2-1-t2, PREEMPT(full). Before: connecting speakers crashed audio. After: clean kernel log, audio works on both speakers and headphones.