### PR TITLE
Add BCM4364 Bluetooth coexistence fixes for MacBookPro16,1

### DIFF
--- a/9010-Bluetooth-hci_bcm-track-usable-reset-resources.patch
+++ b/9010-Bluetooth-hci_bcm-track-usable-reset-resources.patch
@@ -1,0 +1,66 @@
+From bc73241b476f2b97054fe37409555bc1eb608ebe Mon Sep 17 00:00:00 2001
+From: Martin Bastien <martin@pige.dev>
+Date: Wed, 5 Aug 2026 19:46:30 -0400
+Subject: [PATCH 1/4] Bluetooth: hci_bcm: track usable reset resources
+
+Apple platforms provide the Bluetooth reset control through ACPI callbacks
+rather than a GPIO descriptor. Record explicitly whether resource discovery
+found a usable shutdown or reset control, including the Apple callbacks.
+
+Use this state when deciding whether the controller can switch away from
+its initial baud rate. This preserves the safe fallback on generic boards
+whose callback only wraps absent optional GPIOs.
+
+Assisted-by: Codex:GPT-5
+---
+ drivers/bluetooth/hci_bcm.c | 6 +++++-
+ 1 file changed, 5 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/bluetooth/hci_bcm.c b/drivers/bluetooth/hci_bcm.c
+index 1a4fc3882..93ab39db8 100644
+--- a/drivers/bluetooth/hci_bcm.c
++++ b/drivers/bluetooth/hci_bcm.c
+@@ -82,6 +82,7 @@ struct bcm_device_data {
+  *	either by accessing @device_wakeup or by calling @btlp
+  * @set_shutdown: callback to toggle BT_REG_ON pin
+  *	either by accessing @shutdown or by calling @btpu/@btpd
++ * @has_reset_resource: a shutdown or reset control is available
+  * @btlp: Apple ACPI method to toggle BT_WAKE pin ("Bluetooth Low Power")
+  * @btpu: Apple ACPI method to drive BT_REG_ON pin high ("Bluetooth Power Up")
+  * @btpd: Apple ACPI method to drive BT_REG_ON pin low ("Bluetooth Power Down")
+@@ -122,6 +123,7 @@ struct bcm_device {
+ 	struct gpio_desc	*reset;
+ 	int			(*set_device_wakeup)(struct bcm_device *, bool);
+ 	int			(*set_shutdown)(struct bcm_device *, bool);
++	bool			has_reset_resource;
+ #ifdef CONFIG_ACPI
+ 	acpi_handle		btlp, btpu, btpd;
+ 	int			gpio_count;
+@@ -1027,6 +1029,7 @@ static int bcm_apple_get_resources(struct bcm_device *dev)
+ 
+ 	dev->set_device_wakeup = bcm_apple_set_device_wakeup;
+ 	dev->set_shutdown = bcm_apple_set_shutdown;
++	dev->has_reset_resource = true;
+ 
+ 	return 0;
+ }
+@@ -1116,6 +1119,7 @@ static int bcm_get_resources(struct bcm_device *dev)
+ 					     GPIOD_OUT_LOW);
+ 	if (IS_ERR(dev->reset))
+ 		return PTR_ERR(dev->reset);
++	dev->has_reset_resource = dev->shutdown || dev->reset;
+ 
+ 	dev->set_device_wakeup = bcm_gpio_set_device_wakeup;
+ 	dev->set_shutdown = bcm_gpio_set_shutdown;
+@@ -1533,7 +1537,7 @@ static int bcm_serdev_probe(struct serdev_device *serdev)
+ 	if (err)
+ 		return err;
+ 
+-	if (!bcmdev->shutdown) {
++	if (!bcmdev->has_reset_resource) {
+ 		dev_warn(&serdev->dev,
+ 			 "No reset resource, using default baud rate\n");
+ 		bcmdev->oper_speed = bcmdev->init_speed;
+-- 
+2.55.0
+

--- a/9011-Bluetooth-hci_bcm-fix-malformed-legacy-advertising-types.patch
+++ b/9011-Bluetooth-hci_bcm-fix-malformed-legacy-advertising-types.patch
@@ -1,0 +1,113 @@
+From a5b3c764e6c05a06304ec994e5f02cfef2d0b42a Mon Sep 17 00:00:00 2001
+From: Martin Bastien <martin@pige.dev>
+Date: Wed, 5 Aug 2026 19:46:30 -0400
+Subject: [PATCH 2/4] Bluetooth: hci_bcm: fix malformed legacy advertising
+ types
+
+The BCM4364B3 in MacBookPro16,1 systems sets reserved upper bits in
+the event type byte of legacy LE advertising reports. The Bluetooth
+core rejects those reports as unknown, so nearby devices disappear
+from discovery results.
+
+Add a dedicated quirk for masking the vendor bits before validating
+the legacy event type. Keep the DMI match in btbcm setup code so the
+generic event parser remains platform agnostic.
+
+Assisted-by: Codex:GPT-5
+---
+ drivers/bluetooth/btbcm.c   | 14 ++++++++++++++
+ include/net/bluetooth/hci.h | 10 ++++++++++
+ net/bluetooth/hci_event.c   | 11 ++++++++---
+ 3 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
+index 463d59890..35a586841 100644
+--- a/drivers/bluetooth/btbcm.c
++++ b/drivers/bluetooth/btbcm.c
+@@ -20,6 +20,7 @@
+ #include "btbcm.h"
+ 
+ #define VERSION "0.1"
++#define BCM4364_CHIP_ID 150
+ 
+ #define BDADDR_BCM20702A0 (&(bdaddr_t) {{0x00, 0xa0, 0x02, 0x70, 0x20, 0x00}})
+ #define BDADDR_BCM20702A1 (&(bdaddr_t) {{0x00, 0x00, 0xa0, 0x02, 0x70, 0x20}})
+@@ -436,6 +437,16 @@ static const struct dmi_system_id disable_broken_read_transmit_power[] = {
+ 	{ }
+ };
+ 
++static const struct dmi_system_id apple_bcm4364[] = {
++	{
++		.matches = {
++			DMI_MATCH(DMI_BOARD_VENDOR, "Apple Inc."),
++			DMI_MATCH(DMI_PRODUCT_NAME, "MacBookPro16,1"),
++		},
++	},
++	{ }
++};
++
+ static int btbcm_read_info(struct hci_dev *hdev)
+ {
+ 	struct sk_buff *skb;
+@@ -446,6 +457,9 @@ static int btbcm_read_info(struct hci_dev *hdev)
+ 		return PTR_ERR(skb);
+ 
+ 	bt_dev_info(hdev, "BCM: chip id %u", skb->data[1]);
++	if (skb->data[1] == BCM4364_CHIP_ID &&
++	    dmi_first_match(apple_bcm4364))
++		hci_set_quirk(hdev, HCI_QUIRK_FIXUP_LE_ADV_REPORT_EVT_TYPE);
+ 	kfree_skb(skb);
+ 
+ 	return 0;
+diff --git a/include/net/bluetooth/hci.h b/include/net/bluetooth/hci.h
+index 50f0eef71..f7bcffad2 100644
+--- a/include/net/bluetooth/hci.h
++++ b/include/net/bluetooth/hci.h
+@@ -359,6 +359,16 @@ enum {
+ 	 */
+ 	HCI_QUIRK_FIXUP_LE_EXT_ADV_REPORT_PHY,
+ 
++	/*
++	 * When this quirk is set, reserved upper bits in legacy LE
++	 * advertising report event types are discarded. Some Apple/Broadcom
++	 * controllers use those bits for vendor-specific flags.
++	 *
++	 * This quirk can be set before hci_register_dev is called or
++	 * during the hdev->setup vendor callback.
++	 */
++	HCI_QUIRK_FIXUP_LE_ADV_REPORT_EVT_TYPE,
++
+ 	/* When this quirk is set, the HCI_OP_READ_VOICE_SETTING command is
+ 	 * skipped. This is required for a subset of the CSR controller clones
+ 	 * which erroneously claim to support it.
+diff --git a/net/bluetooth/hci_event.c b/net/bluetooth/hci_event.c
+index 741d658e9..ffc7dfd3e 100644
+--- a/net/bluetooth/hci_event.c
++++ b/net/bluetooth/hci_event.c
+@@ -6182,7 +6182,11 @@ static void process_adv_report(struct hci_dev *hdev, u8 type, bdaddr_t *bdaddr,
+ 	struct hci_conn *conn;
+ 	bool match, bdaddr_resolved;
+ 	u32 flags;
+-	u8 *ptr;
++	u8 *ptr, raw_type = type;
++
++	if (hci_test_quirk(hdev,
++			   HCI_QUIRK_FIXUP_LE_ADV_REPORT_EVT_TYPE))
++		type &= 0x07;
+ 
+ 	switch (type) {
+ 	case LE_ADV_IND:
+@@ -6192,8 +6196,9 @@ static void process_adv_report(struct hci_dev *hdev, u8 type, bdaddr_t *bdaddr,
+ 	case LE_ADV_SCAN_RSP:
+ 		break;
+ 	default:
+-		bt_dev_err_ratelimited(hdev, "unknown advertising packet "
+-				       "type: 0x%02x", type);
++		bt_dev_err_ratelimited(hdev,
++				       "unknown advertising packet type: 0x%02x",
++				       raw_type);
+ 		return;
+ 	}
+ 
+-- 
+2.55.0

--- a/9012-Bluetooth-hci_bcm-find-Apple-power-methods-under-BLTH.patch
+++ b/9012-Bluetooth-hci_bcm-find-Apple-power-methods-under-BLTH.patch
@@ -1,0 +1,64 @@
+From 31debc90302d3f688d29086720861d5b5214b922 Mon Sep 17 00:00:00 2001
+From: Martin Bastien <martin@pige.dev>
+Date: Wed, 5 Aug 2026 19:46:30 -0400
+Subject: [PATCH 3/4] Bluetooth: hci_bcm: find Apple power methods under BLTH
+ child
+
+Some Intel Mac ACPI tables place BTLP, BTPU and BTPD below a BLTH
+child of the UART node instead of directly below the UART node. In
+that layout the driver fails to acquire the power controls and falls
+back to generic resources.
+
+Try the existing direct lookup first, then look below the BLTH child
+relative to the same ACPI companion. This avoids hard-coding an
+absolute namespace path or a particular Mac model.
+
+Assisted-by: Codex:GPT-5
+---
+ drivers/bluetooth/hci_bcm.c | 24 +++++++++++++++++++++---
+ 1 file changed, 21 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/bluetooth/hci_bcm.c b/drivers/bluetooth/hci_bcm.c
+index 93ab39db8..08d27432f 100644
+--- a/drivers/bluetooth/hci_bcm.c
++++ b/drivers/bluetooth/hci_bcm.c
+@@ -1012,15 +1012,33 @@ static int bcm_apple_set_shutdown(struct bcm_device *dev, bool powered)
+ 	return 0;
+ }
+ 
++static acpi_status bcm_apple_get_handle(struct acpi_device *adev,
++					const char *name,
++					const char *child_name,
++					acpi_handle *handle)
++{
++	acpi_status status;
++
++	status = acpi_get_handle(adev->handle, (acpi_string)name, handle);
++	if (ACPI_FAILURE(status))
++		status = acpi_get_handle(adev->handle, (acpi_string)child_name,
++					 handle);
++
++	return status;
++}
++
+ static int bcm_apple_get_resources(struct bcm_device *dev)
+ {
+ 	struct acpi_device *adev = ACPI_COMPANION(dev->dev);
+ 	const union acpi_object *obj;
+ 
+ 	if (!adev ||
+-	    ACPI_FAILURE(acpi_get_handle(adev->handle, "BTLP", &dev->btlp)) ||
+-	    ACPI_FAILURE(acpi_get_handle(adev->handle, "BTPU", &dev->btpu)) ||
+-	    ACPI_FAILURE(acpi_get_handle(adev->handle, "BTPD", &dev->btpd)))
++	    ACPI_FAILURE(bcm_apple_get_handle(adev, "BTLP", "BLTH.BTLP",
++					      &dev->btlp)) ||
++	    ACPI_FAILURE(bcm_apple_get_handle(adev, "BTPU", "BLTH.BTPU",
++					      &dev->btpu)) ||
++	    ACPI_FAILURE(bcm_apple_get_handle(adev, "BTPD", "BLTH.BTPD",
++					      &dev->btpd)))
+ 		return -ENODEV;
+ 
+ 	if (!acpi_dev_get_property(adev, "baud", ACPI_TYPE_BUFFER, &obj) &&
+-- 
+2.55.0
+

--- a/9013-Bluetooth-limit-discovery-on-BCM4364-with-active-ACL.patch
+++ b/9013-Bluetooth-limit-discovery-on-BCM4364-with-active-ACL.patch
@@ -1,0 +1,125 @@
+From a4d5c0431327b985f6c34f916a29e7e1233da423 Mon Sep 17 00:00:00 2001
+From: Martin Bastien <martin@pige.dev>
+Date: Wed, 5 Aug 2026 19:46:30 -0400
+Subject: [PATCH 4/4] Bluetooth: limit discovery on BCM4364 with an active ACL
+
+The BCM4364B3 in MacBookPro16,1 systems cannot sustain ACL traffic while
+running the default near-continuous active LE scan or a concurrent BR/EDR
+inquiry. A2DP stalls for the entire 10.24 second LE discovery phase and
+resumes between discovery cycles.
+
+Add a controller quirk which always uses a 30 ms active LE scan window
+every 300 ms, so an ACL created during discovery is protected immediately.
+Omit the BR/EDR phase of interleaved discovery when an ACL exists. Active
+scanning keeps devices visible and permits scan responses.
+
+Restrict the quirk to BCM4364 chip id 150 on MacBookPro16,1 systems.
+
+Assisted-by: Codex:GPT-5
+---
+ drivers/bluetooth/btbcm.c        |  3 +++
+ include/net/bluetooth/hci.h      | 10 ++++++++++
+ include/net/bluetooth/hci_core.h |  2 ++
+ net/bluetooth/hci_sync.c         | 18 ++++++++++++++++--
+ 4 files changed, 31 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/bluetooth/btbcm.c b/drivers/bluetooth/btbcm.c
+index 35a586841..6dfe302a6 100644
+--- a/drivers/bluetooth/btbcm.c
++++ b/drivers/bluetooth/btbcm.c
+@@ -460,6 +460,9 @@ static int btbcm_read_info(struct hci_dev *hdev)
+ 	if (skb->data[1] == BCM4364_CHIP_ID &&
+ 	    dmi_first_match(apple_bcm4364))
+ 		hci_set_quirk(hdev, HCI_QUIRK_FIXUP_LE_ADV_REPORT_EVT_TYPE);
++	if (skb->data[1] == BCM4364_CHIP_ID &&
++	    dmi_first_match(apple_bcm4364))
++		hci_set_quirk(hdev, HCI_QUIRK_BROKEN_DISCOVERY_DURING_ACL);
+ 	kfree_skb(skb);
+ 
+ 	return 0;
+diff --git a/include/net/bluetooth/hci.h b/include/net/bluetooth/hci.h
+index f7bcffad2..d42d02705 100644
+--- a/include/net/bluetooth/hci.h
++++ b/include/net/bluetooth/hci.h
+@@ -369,6 +369,16 @@ enum {
+ 	 */
+ 	HCI_QUIRK_FIXUP_LE_ADV_REPORT_EVT_TYPE,
+ 
++	/*
++	 * When this quirk is set, full-duty LE scanning and BR/EDR inquiry
++	 * can starve an ACL connection. Use low-duty LE discovery so a new ACL
++	 * is protected immediately, and skip inquiry while an ACL is active.
++	 *
++	 * This quirk can be set before hci_register_dev is called or
++	 * during the hdev->setup vendor callback.
++	 */
++	HCI_QUIRK_BROKEN_DISCOVERY_DURING_ACL,
++
+ 	/* When this quirk is set, the HCI_OP_READ_VOICE_SETTING command is
+ 	 * skipped. This is required for a subset of the CSR controller clones
+ 	 * which erroneously claim to support it.
+diff --git a/include/net/bluetooth/hci_core.h b/include/net/bluetooth/hci_core.h
+index 3df59849d..5ef1a4758 100644
+--- a/include/net/bluetooth/hci_core.h
++++ b/include/net/bluetooth/hci_core.h
+@@ -2407,6 +2407,8 @@ void hci_mgmt_chan_unregister(struct hci_mgmt_chan *c);
+ #define DISCOV_CODED_SCAN_INT_SLOW2	0x3000 /* 7.68 sec */
+ #define DISCOV_CODED_SCAN_WIN_SLOW2	0x006c /* 67.5 msec */
+ #define DISCOV_LE_TIMEOUT		10240	/* msec */
++#define DISCOV_LE_LIMITED_SCAN_INT	0x01e0	/* 300 msec */
++#define DISCOV_LE_LIMITED_SCAN_WINDOW	0x0030	/* 30 msec */
+ #define DISCOV_INTERLEAVED_TIMEOUT	5120	/* msec */
+ #define DISCOV_INTERLEAVED_INQUIRY_LEN	0x04
+ #define DISCOV_BREDR_INQUIRY_LEN	0x08
+diff --git a/net/bluetooth/hci_sync.c b/net/bluetooth/hci_sync.c
+index c8d14128c..7b2a60c3d 100644
+--- a/net/bluetooth/hci_sync.c
++++ b/net/bluetooth/hci_sync.c
+@@ -361,6 +361,12 @@ static int interleaved_inquiry_sync(struct hci_dev *hdev, void *data)
+ 	return hci_inquiry_sync(hdev, DISCOV_INTERLEAVED_INQUIRY_LEN, 0);
+ }
+ 
++static bool hci_limit_discovery_during_acl(struct hci_dev *hdev)
++{
++	return hci_test_quirk(hdev, HCI_QUIRK_BROKEN_DISCOVERY_DURING_ACL) &&
++	       hci_conn_num(hdev, ACL_LINK);
++}
++
+ static void le_scan_disable(struct work_struct *work)
+ {
+ 	struct hci_dev *hdev = container_of(work, struct hci_dev,
+@@ -401,6 +407,9 @@ static void le_scan_disable(struct work_struct *work)
+ 		goto _return;
+ 	}
+ 
++	if (hci_limit_discovery_during_acl(hdev))
++		goto discov_stopped;
++
+ 	status = hci_cmd_sync_queue(hdev, interleaved_inquiry_sync, NULL, NULL);
+ 	if (status) {
+ 		bt_dev_err(hdev, "inquiry failed: status %d", status);
+@@ -6146,6 +6155,7 @@ int hci_inquiry_sync(struct hci_dev *hdev, u8 length, u8 num_rsp)
+ static int hci_active_scan_sync(struct hci_dev *hdev, uint16_t interval)
+ {
+ 	u8 own_addr_type;
++	u16 window = hdev->le_scan_window_discovery;
+ 	/* Accept list is not used for discovery */
+ 	u8 filter_policy = 0x00;
+ 	/* Default is to enable duplicates filter */
+@@ -6198,8 +6208,12 @@ static int hci_active_scan_sync(struct hci_dev *hdev, uint16_t interval)
+ 		filter_dup = LE_SCAN_FILTER_DUP_DISABLE;
+ 	}
+ 
+-	err = hci_start_scan_sync(hdev, LE_SCAN_ACTIVE, interval,
+-				  hdev->le_scan_window_discovery,
++	if (hci_test_quirk(hdev, HCI_QUIRK_BROKEN_DISCOVERY_DURING_ACL)) {
++		interval = DISCOV_LE_LIMITED_SCAN_INT;
++		window = DISCOV_LE_LIMITED_SCAN_WINDOW;
++	}
++
++	err = hci_start_scan_sync(hdev, LE_SCAN_ACTIVE, interval, window,
+ 				  own_addr_type, filter_policy, filter_dup);
+ 	if (!err)
+ 		return err;
+-- 
+2.55.0

--- a/9014-wifi-brcmfmac-apply-Apple-BCM4364-coexistence-parameters.patch
+++ b/9014-wifi-brcmfmac-apply-Apple-BCM4364-coexistence-parameters.patch
@@ -1,0 +1,84 @@
+From f35041f37512375569203edb76e18f1316316fd2 Mon Sep 17 00:00:00 2001
+From: Martin Bastien <martin@pige.dev>
+Date: Wed, 5 Aug 2026 21:49:14 -0400
+Subject: [PATCH] wifi: brcmfmac: apply Apple BCM4364 coexistence parameters
+
+Apple's configuration uses four coexistence parameters for the BCM4364 in
+MacBookPro16,1 systems. Apply those values after the FullMAC interface is
+initialized, matching the indexed btc_params interface used by the
+firmware.
+
+Restrict the settings to BCM4364 and MacBookPro16,1. Keep this independent
+of Bluetooth connection state so brcmfmac has no cross-subsystem notifier
+dependency.
+
+Assisted-by: Codex:GPT-5
+---
+ .../broadcom/brcm80211/brcmfmac/btcoex.c      | 31 +++++++++++++++++++
+ 1 file changed, 31 insertions(+)
+
+diff --git a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/btcoex.c b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/btcoex.c
+index 0ca7f8672..5b811aa1c 100644
+--- a/drivers/net/wireless/broadcom/brcm80211/brcmfmac/btcoex.c
++++ b/drivers/net/wireless/broadcom/brcm80211/brcmfmac/btcoex.c
+@@ -4,12 +4,15 @@
+  */
+ #include <linux/slab.h>
+ #include <linux/netdevice.h>
++#include <linux/dmi.h>
+ #include <net/cfg80211.h>
+ 
+ #include <brcmu_wifi.h>
+ #include <brcmu_utils.h>
++#include <brcm_hw_ids.h>
+ #include <defs.h>
+ #include "core.h"
++#include "bus.h"
+ #include "debug.h"
+ #include "fwil.h"
+ #include "fwil_types.h"
+@@ -359,7 +362,19 @@ static void brcmf_btcoex_handler(struct work_struct *work)
+  */
+ int brcmf_btcoex_attach(struct brcmf_cfg80211_info *cfg)
+ {
++	static const struct {
++		u32 addr;
++		u32 value;
++	} apple_btc_params[] = {
++		{ 6, 15 },
++		{ 8, 45000 },
++		{ 9, 15000 },
++		{ 10, 20000 },
++	};
+ 	struct brcmf_btcoex_info *btci;
++	struct brcmf_if *ifp;
++	int err;
++	int i;
+ 	brcmf_dbg(TRACE, "enter\n");
+ 
+ 	btci = kmalloc_obj(*btci);
+@@ -379,6 +394,22 @@ int brcmf_btcoex_attach(struct brcmf_cfg80211_info *cfg)
+ 	INIT_WORK(&btci->work, brcmf_btcoex_handler);
+ 
+ 	cfg->btcoex = btci;
++
++	ifp = brcmf_get_ifp(cfg->pub, 0);
++	if (ifp && cfg->pub->bus_if->chip == BRCM_CC_4364_CHIP_ID &&
++	    dmi_match(DMI_BOARD_VENDOR, "Apple Inc.") &&
++	    dmi_match(DMI_PRODUCT_NAME, "MacBookPro16,1")) {
++		for (i = 0; i < ARRAY_SIZE(apple_btc_params); i++) {
++			u32 addr = apple_btc_params[i].addr;
++			u32 value = apple_btc_params[i].value;
++
++			err = brcmf_btcoex_params_write(ifp, addr, value);
++			if (err)
++				brcmf_err("Apple btc_params %u=%u failed: %d\n",
++					  addr, value, err);
++		}
++	}
++
+ 	return 0;
+ }
+ 
+-- 
+2.55.0


### PR DESCRIPTION
# BCM4364 Bluetooth discovery stalls A2DP on MacBookPro16,1

## Hardware and software

- Model: Apple MacBookPro16,1 (T2)
- Bluetooth/Wi-Fi controller: Broadcom BCM4364
- Distribution: Omarchy / Arch Linux
- Tested kernel: 7.1.5-arch1-Watanare-T2-1-t2
- Bluetooth device used for the audio tests: AirPods

## Problem

Running `bluetoothctl --timeout 60 scan on` while A2DP audio is playing causes
a repeating pattern of approximately 10 seconds without sound followed by only
a few seconds of playback. Nearby devices sometimes appear briefly and
disappear. Avoiding discovery keeps playback stable, but makes pairing another
device impractical.

The issue occurs on both 2.4 GHz and 5 GHz Wi-Fi. Changing bands can change the
severity, but is not a valid fix. Other non-T2 machines running the same
`bluetoothctl` scan do not reproduce the problem.

There were two additional BCM Bluetooth problems during investigation:

1. legacy advertising reports sometimes contain unexpected upper bits in their
   event type, causing devices to be discarded;
2. the MacBookPro16,1 ACPI Bluetooth power methods are beneath the `BLTH` child
   rather than directly beneath the device examined by `hci_bcm`.

## Reproduction

1. Connect AirPods and start continuous audio playback.
2. Run `bluetoothctl --timeout 60 scan on`.
3. Let the command run for its full 60 seconds.
4. Observe long periodic audio stalls and unstable availability of nearby
   devices.

Playback becomes stable again after the command stops discovery.

## What was tested successfully

A prototype on the affected laptop keeps the AirPods stable and retains LE
device discovery by:

- using a 30 ms LE scan window and a 300 ms interval while audio is active;
- avoiding simultaneous classic inquiry while that connection is active;
- accepting the valid low three bits of malformed legacy advertising types;
- fixing the `hci_bcm` shutdown callback and Apple ACPI child lookup; and
- retaining the Apple-specific brcmfmac coexistence parameters established
  during the investigation.

This was tested by running `bluetoothctl --timeout 60 scan on` on both Wi-Fi
bands. The final result had stable audio and no reported Wi-Fi problem.

The brcmfmac parameters alone did not solve the discovery/audio failure. The
Bluetooth scan/inquiry change was required in the successful configuration.

## Candidate patch series

The attached five-patch candidate converts the prototype into kernel quirks
and preserves the Wi-Fi coexistence configuration used during validation:

1. explicitly track whether `hci_bcm` found a usable reset resource;
2. mask malformed legacy advertising types on BCM4364 chip id 150 in a
   MacBookPro16,1;
3. look for Apple power methods below the `BLTH` ACPI child;
4. use a low active LE discovery duty cycle on that controller and skip classic
   inquiry while an ACL connection exists; and
5. apply the four Apple BCM4364 `btc_params` coexistence values in brcmfmac on
   the MacBookPro16,1.

The candidate applies after the current `linux-t2-patches` series on Linux
7.1.4. The affected Bluetooth objects compile with `W=1`. It was also
backported to and boot-tested on 7.1.5-arch1-Watanare-T2-1-t2.

## Runtime validation

The cleaned-up candidate was boot-tested without the prototype's private A2DP
notifier. With AirPods playing continuously,
`bluetoothctl --timeout 60 scan on` completed with completely stable audio and
reported eight nearby devices. No Bluetooth or Wi-Fi driver error was logged.

The test retained the four Apple BCM4364 `btc_params` values established during
the investigation, applied independently by brcmfmac at initialization. The
Bluetooth series has therefore not yet been tested with completely stock
brcmfmac settings, and additional hardware testing is still requested.

Candidate patch 9014 contains that independent brcmfmac configuration so it is
not lost from the exact setup validated on this machine. It is the fifth patch
in the candidate set, remains separate from the four Bluetooth patches, and can
be reviewed independently.

The 9010-9014 filenames are provisional. They were chosen to sort after the
current 9001 patch without reusing previously removed 9002/9003 filenames;
please renumber them to match the patchset's preferred ordering.

It would be useful to determine whether matching DMI plus the reported Broadcom
chip id is sufficient, and whether the brcmfmac coexistence parameters belong
in a separate T2 patch.

## Provenance

The diagnosis was performed interactively on the affected laptop. The candidate
implementation and this report were prepared with Codex (GPT-5) assistance.
The reporter is able to reproduce and hardware-test changes, but is requesting
code review from maintainers familiar with T2 and Bluetooth kernel internals.

No code or report has been submitted to the upstream Linux mailing lists.
