### PR TITLE
i915: 4-lane eDP quirk for MacBookPro15,3

### DIFF
--- a/2010-i915-4-lane-quirk-mbp15-3.patch
+++ b/2010-i915-4-lane-quirk-mbp15-3.patch
@@ -1,0 +1,34 @@
+From: Willy Van Sickle <vansicklewilly@gmail.com>
+Date: Wed, 2 Sep 2026 21:50:00 -0400
+Subject: [PATCH] i915: 4 lane eDP quirk for MacBookPro15,3
+
+The MacBookPro15,3 shares the Coffee Lake-H iGPU + AMD Vega dGPU + T2
+architecture of the MacBookPro15,1 already handled by
+2008-i915-4-lane-quirk-for-mbp15-1. When the firmware boots the panel on the
+discrete GPU it leaves DDI_A_4_LANES clear on the iGPU, so i915 caps DDI A at
+two lanes. The internal 2880x1800 panel needs ~7.9 Gbps (2 lanes give ~5.2 at
+the panel's 2.7 Gbps/lane max), so every mode is pruned and the panel comes up
+with "Cannot find any crtc or sizes".
+
+The 15,3 iGPU reports PCI subsystem id 0x106b:0x019c (shared with the
+MacBookPro16,1). Add it to the existing force-4-lanes quirk table.
+
+Verified on a MacBookPro15,3: forcing DDI_A_4_LANES makes the eDP link train at
+4 lanes and the native 2880x1800 mode return. Without it the connector is
+present with a valid EDID but zero modes.
+---
+ drivers/gpu/drm/i915/display/intel_quirks.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+--- a/drivers/gpu/drm/i915/display/intel_quirks.c
++++ b/drivers/gpu/drm/i915/display/intel_quirks.c
+@@ -274,6 +274,9 @@
+ 
+ 	/* Apple MacBookPro15,1 */
+ 	{ 0x3e9b, 0x106b, 0x0176, quirk_ddi_a_force_4_lanes },
++
++	/* Apple MacBookPro15,3 (iGPU subsys id, shared with MacBookPro16,1) */
++	{ 0x3e9b, 0x106b, 0x019c, quirk_ddi_a_force_4_lanes },
+ };
+ 
+ static const struct intel_dpcd_quirk intel_dpcd_quirks[] = {


### PR DESCRIPTION
Adds a new patch `2010-i915-4-lane-quirk-mbp15-3.patch` extending the existing
`2008-i915-4-lane-quirk-for-mbp15-1` quirk to the **MacBookPro15,3**.

### Problem
The 15,3 shares the Coffee Lake-H iGPU + AMD Vega dGPU + T2 layout of the 15,1.
Its firmware boots the internal panel on the discrete GPU, so it never sets
`DDI_A_4_LANES` on the iGPU. `intel_ddi_max_lanes()` then caps DDI A at two lanes.
The panel (LP154WT5-SJA1, 2880x1800@60, 328.92 MHz) needs ~7.9 Gbps; two lanes at
the panel's 2.7 Gbps/lane DPCD max give ~5.2 Gbps, so every link config is invalid
and i915 prunes the connector to zero modes:

```
[ENCODER:110:DDI A/PHY A] failed to retrieve link info, disabling eDP
Cannot find any crtc or sizes
```

### Fix
The 15,3 iGPU reports PCI subsystem id `0x106b:0x019c` (label shared with the
MacBookPro16,1). Adding it to the existing `quirk_ddi_a_force_4_lanes` table fixes it.
The quirk is a no-op where firmware already sets 4 lanes (`intel_ddi_a_force_4_lanes`
returns early when `ddi_a_4_lanes` is set), so the shared id is safe for the 16,1 too.

### Verified on hardware (MacBookPro15,3)
- `DDI_BUF_CTL_A` (0x64000) at boot = `0x00000081` → `DDI_A_4_LANES` (bit 4) clear.
- A/B on one boot, mux fixed on the iGPU, i915 rebound each pass:
  - bit clear (`0x87`): eDP connected, modes = `[]`
  - bit set (`0x97`): eDP connected, modes = `[2880x1800]`
- Built into a kernel, the quirk fires automatically at probe
  (`[drm] Applying DDI A Forced 4 Lanes quirk`) and the panel comes up on the iGPU
  with no manual register poke.

Tested against the 7.2.2 patchset on a MacBookPro15,3.
