### PR TITLE
bluetooth: strip Broadcom vendor bits from legacy LE adv report type

### DIFF
--- a/9002-Bluetooth-hci_event-strip-Broadcom-vendor-bits-from-adv-type.patch
+++ b/9002-Bluetooth-hci_event-strip-Broadcom-vendor-bits-from-adv-type.patch
@@ -1,0 +1,46 @@
+From e09bde5c4c139e73f244e355f756c857abc0846f Mon Sep 17 00:00:00 2001
+From: Jose Miguel Ochoa <josemiguelo.ochoa@gmail.com>
+Date: Fri, 28 Aug 2026 13:08:15 -0500
+Subject: [PATCH] Bluetooth: hci_event: strip Broadcom vendor bits from legacy
+ adv report type
+
+Broadcom controllers running ROM firmware on T2 Macs (no patchram
+exists, e.g. BCM4364B3 on MacBookPro16,1) set vendor bits
+0x10/0x20/0x80 in the legacy LE Advertising Report Event_Type, so
+ADV_DIRECT_IND arrives as 0x81/0x91/0xa1 and process_adv_report()
+drops it ("unknown advertising packet type"). Bonded LE peripherals
+reconnect via directed adverts, so auto-reconnect only works when a
+report happens to come through clean (~1 in 20); no userspace
+workaround exists since every connect path uses the same
+scan-then-connect code.
+
+The valid type is always in the low nibble: mask it for Broadcom
+controllers when out of range. Valid reports (0x00-0x04) are
+untouched, low nibbles >= 5 are still dropped, and controllers with
+proper firmware never emit these types.
+
+Signed-off-by: Jose Miguel Ochoa <josemiguelo.ochoa@gmail.com>
+---
+ net/bluetooth/hci_event.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/net/bluetooth/hci_event.c b/net/bluetooth/hci_event.c
+index 1b3b913..10afa21 100644
+--- a/net/bluetooth/hci_event.c
++++ b/net/bluetooth/hci_event.c
+@@ -6424,6 +6424,13 @@ static void hci_le_adv_report_evt(struct hci_dev *hdev, void *data,
+
+ 		hci_store_wake_reason(hdev, &info->bdaddr, info->bdaddr_type);
+
++		/* Broadcom ROM firmware (BCM4364B3 on Apple T2 Macs, no
++		 * patchram) sets vendor bits in the legacy Event_Type; the
++		 * valid type is in the low nibble.
++		 */
++		if (hdev->manufacturer == 15 && info->type > LE_ADV_SCAN_RSP)
++			info->type &= 0x0f;
++
+ 		if (info->length <= max_adv_len(hdev)) {
+ 			rssi = info->data[info->length];
+ 			process_adv_report(hdev, info->type, &info->bdaddr,
+--
+2.55.0


### PR DESCRIPTION
## Bluetooth: LE auto-reconnect never fires on BCM4364 (ROM firmware) — strip vendor bits from adv report type

### Hardware / software
- MacBookPro16,1 (T2), Bluetooth BCM4364B3 "Trinidad Olympic" on `hci_uart_bcm`, **ROM firmware** (`BCM (001.016.091) build 0115`; no `brcm/BCM.hcd` exists for this model — t2linux only ships BT firmware for 15,4 / 16,3 / Air9,1)
- Fedora 44, bluez 5.87. Reproduced on `kernel-7.0.10-201.t2.fc44`, `6.19.12-210.t2` and — with the
  stock module — on the current `kernel-7.1.9-200.t2.fc44`, so this is not an old-kernel artifact.
- Peripherals: Logitech MX Master 3 (BLE HID), Keychron K15 Max (BLE HID)

### TLDR
**Issue**: On T2 Macs where the BCM4364 runs ROM firmware (t2linux ships no .hcd for these models), the controller sets vendor bits in the Event_Type of legacy LE Advertising Reports (0x81/0xa1/…), so process_adv_report() discards ~95% of bonded peripherals' directed reconnect adverts — BLE devices stay disconnected on wake until a rare clean report slips through.

**Fix**: For Broadcom controllers only (hdev->manufacturer == 15), mask an out-of-range Event_Type to its low nibble before validation — reports that are valid today take the same path as before, and Broadcom controllers with real firmware never emit these types, so the quirk is inert everywhere else.

Only these two devices? No — the corruption happens on the local controller, so every bonded BLE peripheral is affected; the mouse and keyboard are just the two I own. BR/EDR devices are untouched (my Sony earbuds on the same machine reconnect fine — classic paging doesn't go through this path).

<details>
<summary>Long explanation</summary>

### Symptom
Bonded LE HID devices don't reconnect when woken. `dmesg` fills with

```
Bluetooth: hci0: unknown advertising packet type: 0x81
Bluetooth: hci0: unknown advertising packet type: 0xa1
Bluetooth: hci0: unknown advertising packet type: 0x91
```

Tally over several boots (144 drops): `0xa1`×35 `0x81`×35 `0x91`×17 `0x11`×8 `0x21`×6 `0x90`×4 `0x80`×4 `0x14`×4 `0xa0`×3 `0x10`×2 `0xa2` `0x93` `0x24` `0x23`. The low nibble is always a valid legacy type (0–4); the upper nibble is `0x1/0x2/0x8/0x9/0xa` vendor noise.

### Root cause (btmon)
The controller reports the mouse's reconnect adverts with garbage high bits in `Event_Type` most of the time, and cleanly sometimes:

```
> HCI Event: LE Meta Event (0x3e) plen 12          2026-08-28 11:37:40
      LE Advertising Report (0x02)
        Event type: Reserved (0x81)                 <- dropped by process_adv_report()
        Address: E8:BB:F0:C3:98:2F (Static)
        Data length: 0

> HCI Event: LE Meta Event (0x3e) plen 12          2026-08-28 11:38:20
      LE Advertising Report (0x02)
        Event type: Connectable directed - ADV_DIRECT_IND (0x01)
        Address: E8:BB:F0:C3:98:2F (Static)
< HCI Command: LE Create Connection (0x08|0x000d)   +3 ms
> HCI Event: LE Enhanced Connection Complete       +70 ms, Status: Success
> HCI Event: Encryption Change                      Enabled with AES-CCM
kernel: logitech-hidpp-device ...: HID++ 4.5 device connected.
```

`hci_le_adv_report_evt()` → `process_adv_report()` rejects any type > `LE_ADV_SCAN_RSP`, so the passive-scan auto-connect for bonded peripherals never triggers on the mangled reports. Reconnection only happens when a report slips through clean (~1 in 20). Every userspace path (`bluetoothctl connect`, L2CAP sockets) goes through the same scan-then-connect code, so no userspace workaround exists — a `bluetoothctl connect` loop only raises the odds.

### Fix
Mask the type to its low nibble for Broadcom controllers (`hdev->manufacturer == 15`) when it is out of range, before validation. 2 lines of logic in `net/bluetooth/hci_event.c`; other vendors untouched.

This repo has carried the same shape of quirk before: `9001-Bluetooth-hci_event-Add-quirk-to-ignore-byte-in-LE-Extended-Adv-Report.patch` patched the *extended* adv report path in this very file for T2 controllers. This is the legacy-report counterpart.

### Scope / risk
- Keyed on the **local controller** (`hdev->manufacturer == 15`), not on the peer device, and only for `Event_Type > 0x04` — reports that were being discarded anyway. Valid reports (0x0–0x4) take the exact same path as before, so devices that work today are unaffected; the BR/EDR path is not involved.
- Low nibbles ≥ 5 stay invalid and are still dropped.
- Broadcom controllers with proper firmware never emit such types → inert there.
- Worst case if the low nibble were ever wrong (never observed in 144 samples; the same mouse also emits the clean `0x01` for the same packet): a stray `LE Create Connection` that times out after a few seconds. No effect on established links.

</details>
