### PR TITLE
apple-gmux: fix force_igd parameter name and printk newlines

### DIFF
--- a/2009-apple-gmux-allow-switching-to-igpu-at-probe.patch
+++ b/2009-apple-gmux-allow-switching-to-igpu-at-probe.patch
@@ -79,7 +79,7 @@ index 1417e230edbd..e69785af8e1d 100644
  
 +static bool force_igd;
 +module_param(force_igd, bool, 0);
-+MODULE_PARM_DESC(force_idg, "Switch gpu to igd on module load. Make sure that you have apple-set-os set up and the iGPU is in `lspci -s 00:02.0`. (default: false) (bool)");
++MODULE_PARM_DESC(force_igd, "Switch gpu to igd on module load. Make sure that you have apple-set-os set up and the iGPU is in `lspci -s 00:02.0`. (default: false) (bool)");
 +
  static u8 gmux_pio_read8(struct apple_gmux_data *gmux_data, int port)
  {
@@ -97,7 +97,7 @@ index 1417e230edbd..e69785af8e1d 100644
 +			gmux_switchto(VGA_SWITCHEROO_IGD);
 +			vga_set_default_device(pdev);
 +		} else {
-+			pr_err("force_idg is true, but couldn't find iGPU at 00:02.0! Is apple-set-os working?");
++			pr_err("force_igd is true, but couldn't find iGPU at 00:02.0! Is apple-set-os working?");
 +		}
 +	}
 +

--- a/2009-apple-gmux-allow-switching-to-igpu-at-probe.patch
+++ b/2009-apple-gmux-allow-switching-to-igpu-at-probe.patch
@@ -93,11 +93,11 @@ index 1417e230edbd..e69785af8e1d 100644
 +
 +		pdev = pci_get_domain_bus_and_slot(0, 0, PCI_DEVFN(2, 0));
 +		if (pdev) {
-+			pr_info("Switching to IGD");
++			pr_info("Switching to IGD\n");
 +			gmux_switchto(VGA_SWITCHEROO_IGD);
 +			vga_set_default_device(pdev);
 +		} else {
-+			pr_err("force_igd is true, but couldn't find iGPU at 00:02.0! Is apple-set-os working?");
++			pr_err("force_igd is true, but couldn't find iGPU at 00:02.0! Is apple-set-os working?\n");
 +		}
 +	}
 +


### PR DESCRIPTION
Two small fixes to `2009-apple-gmux-allow-switching-to-igpu-at-probe.patch`. No functional change; three lines total, all inside string literals.

### 1. `MODULE_PARM_DESC` and `pr_err` misspell the parameter as `force_idg`

The parameter is declared correctly:

```c
static bool force_igd;
module_param(force_igd, bool, 0);
MODULE_PARM_DESC(force_idg, "Switch gpu to igd on module load. ...");
```

so `modinfo` hangs the description on a name that does not exist and leaves the real parameter undocumented:

```
parm: force_idg:Switch gpu to igd on module load. Make sure that you have
      apple-set-os set up and the iGPU is in `lspci -s 00:02.0`. (default: false) (bool)
parm: force_igd:bool
```

Anyone reading `modinfo` to find out how to enable the iGPU will try `force_idg=y`, which is silently ignored — no effect, no diagnostic. `apple_gmux.force_idg=1` on the kernel command line is equally silent.

The probe-failure message names the same non-existent parameter, which sends people hunting for a typo in their own configuration instead of looking at apple-set-os.

I hit this myself on a MacBookPro16,1 while working out why the iGPU was not enumerated, and spent a while assuming the two names were two different knobs.

### 2. The two `printk` calls have no trailing newline

`pr_info("Switching to IGD")` and the `pr_err` above both omit `\n`, so printk keeps the line buffered and whatever logs next gets appended. On this path that is likely — `gmux_probe()` continues straight into eDP pre-calibration, and the i915/amdgpu probes follow shortly after.

### What was and was not verified

Verified:
* `apple_gmux.force_igd=1` works as intended on MacBookPro16,1 (Navi 14 + UHD 630, kernel 6.18.48) with the **unmodified** patch — the mux switches to IGD and the panel comes up on i915.
* Both misspellings confirmed present in the built module (`strings apple-gmux.ko`).
* `force_igd` does not exist in mainline, so this is downstream-only.
* Hunk line counts are unchanged and `git apply --stat` still parses, so the patch applies exactly as before.

**Not verified: no kernel was rebuilt from the edited patch.** The changes are confined to string literals, but I have not compiled them. Flagging that explicitly rather than implying more testing than was done.

Split into two commits so the name fix can be taken independently of the newline cleanup.

Prepared with AI assistance; tagged `Assisted-by: LLM` per `Documentation/process/coding-assistants.rst`. `Signed-off-by` is mine and I take responsibility for the contribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JguFWmdFyNDLAbYAouKZPU