### PR TITLE
drm/amd/pm: defer UCLK DPM enablement on Apple Navi 14 0218

### DIFF
--- a/6002-drm-amd-pm-defer-UCLK-DPM-on-Apple-0218.patch
+++ b/6002-drm-amd-pm-defer-UCLK-DPM-on-Apple-0218.patch
@@ -1,0 +1,156 @@
+From d98420bcedd17ecfd3089749589afa1d9aa72f3e Mon Sep 17 00:00:00 2001
+From: Ed Schofield <ed@aicharmers.com>
+Date: Tue, 8 Sep 2026 14:35:05 +1000
+Subject: [PATCH] drm/amd/pm: defer UCLK DPM enablement on Apple Navi 14 0218
+
+On the Apple 1002:7340/106b:0218 revision 41 board, enabling UCLK DPM
+with EnableAllSmuFeatures can time out and leave amdgpu without a DRM
+device. Omitting only UCLK avoids that timeout; enabling it separately
+immediately afterwards still timed out in a local experiment.
+
+Defer UCLK enablement to the Navi post-init callback, then verify the
+firmware bit and refresh the supported-feature bit, memory DPM table
+and sustainable clock limits before the UMC workaround and UMD setup.
+Validate the PPT memory states consumed by DCN20 before that callback.
+Keep both memory-voltage features enabled and respect PP_MCLK_DPM_MASK.
+Limit the change to the board and revision tested locally.
+
+Based on Atharva Tiwari's delayed-UCLK proposal for Apple board 0219.
+This adaptation uses the Navi callback and updates driver clock state;
+it does not change T2's existing 0219 allowed-mask workaround.
+
+Link: https://www.mail-archive.com/amd-gfx@lists.freedesktop.org/msg149770.html
+Link: https://github.com/t2linux/kernel/issues/19#issuecomment-5537823876
+Assisted-by: LLM
+---
+ .../gpu/drm/amd/pm/swsmu/smu11/navi10_ppt.c   | 79 ++++++++++++++++++-
+ 1 file changed, 78 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/amd/pm/swsmu/smu11/navi10_ppt.c b/drivers/gpu/drm/amd/pm/swsmu/smu11/navi10_ppt.c
+index 6dfc3b585..3e6baa4ae 100644
+--- a/drivers/gpu/drm/amd/pm/swsmu/smu11/navi10_ppt.c
++++ b/drivers/gpu/drm/amd/pm/swsmu/smu11/navi10_ppt.c
+@@ -58,6 +58,18 @@
+ #undef pr_info
+ #undef pr_debug
+ 
++static bool navi14_needs_late_uclk(struct amdgpu_device *adev)
++{
++	struct pci_dev *pdev = adev->pdev;
++
++	return pdev->vendor == PCI_VENDOR_ID_ATI &&
++		pdev->device == 0x7340 &&
++		pdev->subsystem_vendor == PCI_VENDOR_ID_APPLE &&
++		pdev->subsystem_device == 0x0218 &&
++		pdev->revision == 0x41 &&
++		(adev->pm.pp_feature & PP_MCLK_DPM_MASK);
++}
++
+ static const struct smu_feature_bits navi10_dpm_features = {
+ 	.bits = {
+ 		SMU_FEATURE_BIT_INIT(FEATURE_DPM_PREFETCHER_BIT),
+@@ -354,6 +366,11 @@ navi10_init_allowed_features(struct smu_context *smu)
+ 		smu_feature_list_set_bit(smu, SMU_FEATURE_LIST_ALLOWED, FEATURE_MEM_MVDD_SCALING_BIT);
+ 	}
+ 
++	/* This board times out if EnableAllSmuFeatures includes UCLK DPM. */
++	if (navi14_needs_late_uclk(adev))
++		smu_feature_list_clear_bit(smu, SMU_FEATURE_LIST_ALLOWED,
++					   FEATURE_DPM_UCLK_BIT);
++
+ 	if (is_asic_secure(smu) &&
+ 	    (amdgpu_ip_version(adev, MP1_HWIP, 0) == IP_VERSION(11, 0, 0)) &&
+ 	    (adev->rev_id == 0))
+@@ -468,6 +485,25 @@ static int navi10_store_powerplay_table(struct smu_context *smu)
+ 	return 0;
+ }
+ 
++/* DCN20 consumes these PPT states before the post-init UCLK enable. */
++static int navi14_imac_check_uclk_states(struct smu_context *smu)
++{
++	PPTable_t *ppt = smu->smu_table.driver_pptable;
++	unsigned int count, i;
++
++	if (!navi14_needs_late_uclk(smu->adev))
++		return 0;
++
++	count = ppt->DpmDescriptor[PPCLK_UCLK].NumDiscreteLevels;
++	if (!count || count > ARRAY_SIZE(ppt->FreqTableUclk))
++		return -EINVAL;
++	for (i = 0; i < count; i++) {
++		if (!ppt->FreqTableUclk[i])
++			return -EINVAL;
++	}
++	return 0;
++}
++
+ static int navi10_setup_pptable(struct smu_context *smu)
+ {
+ 	int ret = 0;
+@@ -488,7 +524,7 @@ static int navi10_setup_pptable(struct smu_context *smu)
+ 	if (ret)
+ 		return ret;
+ 
+-	return ret;
++	return navi14_imac_check_uclk_states(smu);
+ }
+ 
+ static int navi10_tables_init(struct smu_context *smu)
+@@ -3212,6 +3248,41 @@ static int navi10_enable_mgpu_fan_boost(struct smu_context *smu)
+ 					       NULL);
+ }
+ 
++/* Rebuild memory clocks before the UMC workaround and UMD clock setup. */
++static int navi14_imac_late_uclk_enable(struct smu_context *smu)
++{
++	struct smu_11_0_dpm_context *dpm = smu->smu_dpm.dpm_context;
++	struct smu_dpm_table *table = &dpm->dpm_tables.uclk_table;
++	PPTable_t *ppt = smu->smu_table.driver_pptable;
++	struct smu_feature_bits enabled;
++	int ret;
++
++	if (!navi14_needs_late_uclk(smu->adev))
++		return 0;
++
++	ret = smu_cmn_feature_set_enabled(smu, SMU_FEATURE_DPM_UCLK_BIT, true);
++	if (ret)
++		return ret;
++	ret = smu_cmn_get_enabled_mask(smu, &enabled);
++	if (ret)
++		return ret;
++	if (!smu_feature_bits_is_set(&enabled, FEATURE_DPM_UCLK_BIT))
++		return -EIO;
++
++	smu_feature_list_set_bit(smu, SMU_FEATURE_LIST_SUPPORTED,
++				 FEATURE_DPM_UCLK_BIT);
++	table->clk_type = SMU_UCLK;
++	ret = smu_v11_0_set_single_dpm_table(smu, SMU_UCLK, table);
++	if (ret)
++		return ret;
++	if (!table->count)
++		return -EINVAL;
++	if (!ppt->DpmDescriptor[PPCLK_UCLK].SnapToDiscrete)
++		table->flags |= SMU_DPM_TABLE_FINE_GRAINED;
++
++	return smu_v11_0_init_max_sustainable_clocks(smu);
++}
++
+ static int navi10_post_smu_init(struct smu_context *smu)
+ {
+ 	struct amdgpu_device *adev = smu->adev;
+@@ -3220,6 +3291,12 @@ static int navi10_post_smu_init(struct smu_context *smu)
+ 	if (amdgpu_sriov_vf(adev))
+ 		return 0;
+ 
++	ret = navi14_imac_late_uclk_enable(smu);
++	if (ret) {
++		dev_err(adev->dev, "Failed to enable late UCLK DPM: %d\n", ret);
++		return ret;
++	}
++
+ 	ret = navi10_run_umc_cdr_workaround(smu);
+ 	if (ret)
+ 		dev_err(adev->dev, "Failed to apply umc cdr workaround!\n");
+-- 
+2.55.0
+

--- a/6002-drm-amd-pm-defer-UCLK-DPM-on-Apple-0218.patch
+++ b/6002-drm-amd-pm-defer-UCLK-DPM-on-Apple-0218.patch
@@ -3,9 +3,9 @@ From: Ed Schofield <ed@aicharmers.com>
 Date: Tue, 8 Sep 2026 14:35:05 +1000
 Subject: [PATCH] drm/amd/pm: defer UCLK DPM enablement on Apple Navi 14 0218
 
-On the Apple 1002:7340/106b:0218 revision 41 board, enabling UCLK DPM
-with EnableAllSmuFeatures can time out and leave amdgpu without a DRM
-device. Omitting only UCLK avoids that timeout; enabling it separately
+On the Apple iMac 1002:7340/106b:0218 revision 41 board, enabling UCLK
+DPM with EnableAllSmuFeatures can time out and leave amdgpu without a
+DRM device. Omitting only UCLK avoids that timeout; enabling it separately
 immediately afterwards still timed out in a local experiment.
 
 Defer UCLK enablement to the Navi post-init callback, then verify the
@@ -22,6 +22,7 @@ it does not change T2's existing 0219 allowed-mask workaround.
 Link: https://www.mail-archive.com/amd-gfx@lists.freedesktop.org/msg149770.html
 Link: https://github.com/t2linux/kernel/issues/19#issuecomment-5537823876
 Assisted-by: LLM
+Signed-off-by: Ed Schofield <ed@aicharmers.com>
 ---
  .../gpu/drm/amd/pm/swsmu/smu11/navi10_ppt.c   | 79 ++++++++++++++++++-
  1 file changed, 78 insertions(+), 1 deletion(-)
@@ -153,4 +154,3 @@ index 6dfc3b585..3e6baa4ae 100644
  		dev_err(adev->dev, "Failed to apply umc cdr workaround!\n");
 -- 
 2.55.0
-


### PR DESCRIPTION
On an iMac20,1 (2020, 27") with GPU `1002:7340 / 106b:0218`, revision `41`, the normal `EnableAllSmuFeatures` request can time out with error `-62`, leaving no AMDGPU DRM device. This patch leaves UCLK DPM out of that request and enables it from Navi's post-init callback. It then verifies the firmware bit and refreshes the driver's supported-feature bit, memory DPM table and sustainable clock limits.

Both memory-voltage features stay enabled during normal initialization. The patch respects `PP_MCLK_DPM_MASK`, validates the PPT memory states consumed by DCN20, and matches only the tested `0218/41` board. It leaves [patch 6001](https://github.com/t2linux/linux-t2-patches/blob/1ed4126844013f7e6fb3c8b0347cf0c5d6f99ffa/6001-drm-amd-pm-Fix-boot-problems-in-5300.patch)'s `0219` workaround unchanged.

This follows Atharva Tiwari's [delayed-UCLK proposal for 0219](https://www.mail-archive.com/amd-gfx@lists.freedesktop.org/msg149770.html). I described results with my hardware in
[the September 4 comment on kernel issue 19](https://github.com/t2linux/kernel/issues/19#issuecomment-5537823876). Enabling UCLK separately immediately after enable-all failed in an earlier
experiment; the later callback is the tested point in initialization. The results do not establish the firmware's internal cause.

Here's the testing I've done on my iMac:

| Implementation | Evidence |
| --- | --- |
| Experimental test3 | 40 successful warm boots and 10 cold boots: eight with AC connected, two with the iMac unplugged after orderly shutdown |
| Same-kernel control | Restoring the original policy reproduced the enable-all timeout; delayed-UCLK warm recovery passed |
| This production patch on T2 7.2.3 | Normal warm boot, hardware rendering, VAAPI H.264 comparison, and sustained rendering with all four memory states observed |
| Production cold conditions | Prescribed AC-connected and AC-unplugged starts passed, with operator-confirmed 60-second intervals and rendering/video checks; an additional AC-connected power-on also passed and is recorded separately |
| Production public-policy exclusion | Separate warm boot with MCLK DPM disabled; expected fixed state, rendering and VAAPI pass |
| Production memory/update checks | Ten-minute Vulkan memory test with 2 GiB budget and load/idle/load transition; normal boot/render/video pass after a full system update and initramfs regeneration |
| Build and host checks | Full T2 build, module inventory/depmod checks, and 49,177 extracted-C cases with ASan/UBSan and mocked firmware |

The build uses Arch `v7.2.3-arch1` plus T2 patch collection `1ed4126844013f7e6fb3c8b0347cf0c5d6f99ffa`. Historical counts belong to the experimental implementation. An intended unplugged start was corrected to AC-connected when the operator clarified the sequence; the actual unplugged check was then performed and confirmed. Other Apple boards, macOS-predecessor starts, suspend/resume and native 5K have not been validated. Boot-time MCE and Bluetooth observations remain outside this GPU initialization patch.

I would appreciate review of the callback ordering and clock-state updates, and testing on other affected hardware before considering a broader match. The intended destination is AMDGPU upstream; carrying it in T2 would also make the tested fix available to affected users.

This work was prompted by frequent, intermittent boot failures on my iMac due to the GPU not being initialized. I used Codex / GPT-6 to do the source investigation, patch implementation, test scripts, as well as then by requests to isolate the UCLK sequencing change, retain public policy behaviour and validate a production extraction. The checks above include compiled C, real hardware and an original-policy control; the host tests use mocked firmware.

Formatting checks: `checkpatch --strict --no-signoff` reports zero errors, two warnings and five checks. The warnings concern the accessible mail-archive link and the older assistance-trailer format expected by the checked-out checker; the five checks concern existing firmware-interface CamelCase names.
